### PR TITLE
promote your skip_whitespace() method from postprocess to default behavior

### DIFF
--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -90,7 +90,7 @@ class XMLToDictTestCase(unittest.TestCase):
         """
         self.assertEqual(
             xmltodict.parse(xml),
-            {'root': {'emptyb': {'@attr': 'attrvalue'}, 'value': 'hello'}})
+            {'root': {'emptya': None, 'emptyb': {'@attr': 'attrvalue'}, 'value': 'hello'}})
 
     def test_streaming(self):
         def cb(path, item):

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -81,7 +81,7 @@ class _DictSAXHandler(object):
         if len(self.stack):
             item, data = self.item, self.data
             if data is not None:
-                data = data.strip()
+                data = data.strip() or None
             self.item, self.data = self.stack.pop()
             if data and self.force_cdata and item is None:
                 item = self.dict_constructor()


### PR DESCRIPTION
skip whitespace that is present in the incoming xml.

all unittests pass.  I made a failing case first, that is brought back into compliance with the patch to push_data().
