### PR TITLE
Fixed namespace parsing bug by removing **kwargs from the handler

### DIFF
--- a/xmltodict.py
+++ b/xmltodict.py
@@ -216,7 +216,7 @@ def parse(xml_input, encoding='utf-8', expat=expat, process_namespaces=False,
         OrderedDict([(u'a', u'hello')])
 
     """
-    handler = _DictSAXHandler(namespace_separator=namespace_separator, **kwargs)
+    handler = _DictSAXHandler(namespace_separator=namespace_separator)
     parser = expat.ParserCreate(
         encoding,
         namespace_separator if process_namespaces else None


### PR DESCRIPTION
the handler was throwing a kwargs error because it doesn't understand the process_namespaces kwarg.  I removed it, tested quickly, and verified this change restores the process_namespaces feature. 
