### PR TITLE
Improve performance for large files

### DIFF
--- a/xmltodict.py
+++ b/xmltodict.py
@@ -239,6 +239,7 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
     parser.StartElementHandler = handler.startElement
     parser.EndElementHandler = handler.endElement
     parser.CharacterDataHandler = handler.characters
+    parser.buffer_text = True
     try:
         parser.ParseFile(xml_input)
     except (TypeError, AttributeError):


### PR DESCRIPTION
xmltodict becomes slow when you have an XML file with large texts.
Enabling the parser.buffer_text option dramatically increases performance.
Benchmark below. Unittests still work.

Code used to benchmark:

<pre>
import xmltodict
import time
xml = "&lt;root>" + ("a"*70+"\n")*10000 + "&lt;/root>"
s=time.time()
x=xmltodict.parse(xml)
print(time.time() - s)
</pre>

 #19.9860811234 seconds without buffer_text
 #0.059289932251 seconds with buffer_text
 # So 300 times faster
