### PR TITLE
Allow generators in input dicts for unparse() #91

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -49,6 +49,14 @@ class DictToXMLTestCase(unittest.TestCase):
         self.assertEqual(obj, parse(unparse(obj)))
         self.assertEqual(unparse(obj), unparse(parse(unparse(obj))))
 
+    def test_generator(self):
+        obj = {'a': {'b': ['1', '2', '3']}}
+        def lazy_obj():
+            return {'a': {'b': (i for i in ('1', '2', '3'))}}
+        self.assertEqual(obj, parse(unparse(lazy_obj())))
+        self.assertEqual(unparse(lazy_obj()),
+             unparse(parse(unparse(lazy_obj()))))
+
     def test_no_root(self):
         self.assertRaises(ValueError, unparse, {})
 

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -265,9 +265,9 @@ def _emit(key, value, content_handler,
         key, value = result
     if not isinstance(value, (list, tuple)):
         value = [value]
-    if full_document and depth == 0 and len(value) > 1:
-        raise ValueError('document with multiple roots')
-    for v in value:
+    for index, v in enumerate(value):
+        if full_document and depth == 0 and index > 0:
+            raise ValueError('document with multiple roots')
         if v is None:
             v = OrderedDict()
         elif not isinstance(v, dict):

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -28,6 +28,8 @@ try:  # pragma no cover
 except NameError:  # pragma no cover
     _unicode = str
 
+import types
+
 __author__ = 'Martin Blech'
 __version__ = '0.9.2'
 __license__ = 'MIT'
@@ -263,7 +265,7 @@ def _emit(key, value, content_handler,
         if result is None:
             return
         key, value = result
-    if not isinstance(value, (list, tuple)):
+    if not isinstance(value, (list, tuple, types.GeneratorType)):
         value = [value]
     for index, v in enumerate(value):
         if full_document and depth == 0 and index > 0:


### PR DESCRIPTION
This should solve the issue [Allow generators in input dicts for unparse() #91](https://github.com/martinblech/xmltodict/issues/91).

- a generator is also allowed (besides list and tuple) to represent node children in the `_emit()` function
- single root is checked inside the loop (with index taken eg. via `enumerate()`) - without the need for materializing the whole sequence
- a test is added that supplies an `OrderedDict` containing a generator to `unparse()`