### PR TITLE
Several Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ It also lets you collapse certain namespaces to shorthand prefixes, or skip them
 True
 ```
 
-## Streaming mode
+## Streaming Mode
 
 `xmltodict` is very fast ([Expat](http://docs.python.org/library/pyexpat.html)-based) and has a streaming mode with a small memory footprint, suitable for big XML dumps like [Discogs](http://discogs.com/data/) or [Wikipedia](http://dumps.wikimedia.org/).
 
@@ -82,7 +82,7 @@ In the streaming mode, intermediate values are returned during parsing (rather t
 
 You activate streaming mode by calling the parser with a `generator` argument that evaluates to True and/or an `item_depth` argument that is greater than 0.
 
-### Generator/Iterator
+### Streaming Mode: Generator/Iterator
 
 If the `generator` argument evaluates to True, the function returns an iterator. On each iteration, it returns a new node from the specified `item_depth`. (An `item_depth` of 0 will return the full tree, an `item_depth` of 1 will return the contents of the root tag, an `item_depth` of 2 will return the contents of the tags of the root element's children, etc.) Each iteration returns a tuple of the `path` from the document root to the item (name-attribs pairs) and the `item` (the contents of the item). The contents of the item will be the value of the sub-node. If the sub-node is an XML tree that would be represened by a dictionary, the iterator will return a dictionary as the `item`. If the sub-node only contains CDATA that would be represented in a text node, the iterator will return a text node as the `item`. If the node is an empty tag which would be represented by None, the iterator returns None as the `item`.
 
@@ -92,7 +92,7 @@ Example:
 ... <a prop="x">
 ...   <b>1</b>
 ...   <b>2</b>
-... </a>\"\"\"
+... </a>"""
 >>> for (path, item) in xmltodict.parse(xml, generator=True, item_depth=2):
 ...     print 'path:%s item:%s' % (path, item)
 ...
@@ -100,7 +100,7 @@ path:[(u'a', {u'prop': u'x'}), (u'b', None)] item:1
 path:[(u'a', {u'prop': u'x'}), (u'b', None)] item:2
 ```
 
-### Callback
+### Streaming Mode: Callback
 
 If `item_depth` is greater than 0 and the user specifies an `item_callback`, it will call the `item_callback` every time an item at the specified depth is found.
 
@@ -113,11 +113,11 @@ The `item_callback` function receives the same parameters returned by the `gener
 ...     print 'path:%s item:%s' % (path, item)
 ...     return True
 ...
->>> xml = \"\"\"\\
+>>> xml = """\
 ... <a prop="x">
 ...   <b>1</b>
 ...   <b>2</b>
-... </a>\"\"\"
+... </a>"""
 >>> xmltodict.parse(xml, item_depth=2, item_callback=handle)
 path:[(u'a', {u'prop': u'x'}), (u'b', None)] item:1
 path:[(u'a', {u'prop': u'x'}), (u'b', None)] item:2

--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -1,5 +1,5 @@
 import sys
-from xmltodict import parse, unparse, OrderedDict
+from xmltodict import parse, unparse, OrderedDict, XMLDictNode
 
 try:
     import unittest2 as unittest
@@ -155,3 +155,56 @@ class DictToXMLTestCase(unittest.TestCase):
         self.assertTrue(xml_declaration_re.match(unparse({'a': 1})))
         self.assertFalse(
             xml_declaration_re.match(unparse({'a': 1}, full_document=False)))
+
+    def test_index_keys_with_compress_dict(self):
+        obj = {
+            'a': {
+                'key': {
+                    'c': 'key',
+                    '#tag': 'b',
+                }
+            }
+        }
+        expectedResult = '<a><b><c>key</c></b></a>'
+        self.assertEqual(unparse(obj, full_document=False), expectedResult)
+
+    def test_index_keys_with_compress_newstyle(self):
+        obj = {
+            'a': {
+                'key': XMLDictNode({
+                    'c': 'key',
+                }),
+            }
+        }
+        setattr(obj['a']['key'], "#tag", 'b')
+        expectedResult = '<a><b><c>key</c></b></a>'
+        self.assertEqual(unparse(obj, full_document=False), expectedResult)
+
+    def test_index_keys_without_compress_dict(self):
+        obj = {
+            'a': {
+                'b': {
+                    'key': {
+                        'c': 'key',
+                    },
+                    '#deletelevel': True,
+                }
+            }
+        }
+        expectedResult = '<a><b><c>key</c></b></a>'
+        self.assertEqual(unparse(obj, full_document=False), expectedResult)
+
+    def test_index_keys_without_compress_newstyle(self):
+        obj = {
+            'a': {
+                'b': XMLDictNode({
+                    'key': {
+                        'c': 'key',
+                    }
+                }),
+            }
+        }
+        obj['a']['b']['foo'] = [{'c': 'foo'}, {'c': 'foo'}]
+        setattr(obj['a']['b'], "#deletelevel", True)
+        expectedResult = '<a><b><c>key</c></b><b><c>foo</c></b><b><c>foo</c></b></a>'
+        self.assertEqual(unparse(obj, full_document=False), expectedResult)

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -94,10 +94,10 @@ class XMLToDictTestCase(unittest.TestCase):
                          expectedResult)
         rv = self.parse(xml, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv.has_xml_attrs())
         rv = self.parse(xml, force_cdata=True, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv.has_xml_attrs())
 
     def test_simple(self):
         xml = '<a>data</a>'
@@ -106,8 +106,8 @@ class XMLToDictTestCase(unittest.TestCase):
         self.assertEqual(self.parse(xml), expectedResult)
         rv = self.parse(xml, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
-        self.assertEqual(rv.getXMLattributes(), {})
+        self.assertFalse(rv.has_xml_attrs())
+        self.assertEqual(rv.get_xml_attrs(), {})
 
     def test_list_simple(self):
         xml = '<a><b>data1</b><b>data2</b></a>'
@@ -116,12 +116,12 @@ class XMLToDictTestCase(unittest.TestCase):
         self.assertEqual(self.parse(xml), expectedResult)
         rv = self.parse(xml, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
-        self.assertEqual(rv.getXMLattributes(), {})
-        self.assertFalse(rv['a'].hasXMLattributes())
-        self.assertFalse(rv['a']['b'].hasXMLattributes())
-        self.assertFalse(rv['a']['b'][0].hasXMLattributes())
-        self.assertFalse(rv['a']['b'][1].hasXMLattributes())
+        self.assertFalse(rv.has_xml_attrs())
+        self.assertEqual(rv.get_xml_attrs(), {})
+        self.assertFalse(rv['a'].has_xml_attrs())
+        self.assertFalse(rv['a']['b'].has_xml_attrs())
+        self.assertFalse(rv['a']['b'][0].has_xml_attrs())
+        self.assertFalse(rv['a']['b'][1].has_xml_attrs())
 
     def test_force_cdata(self):
         xml = '<a>data</a>'
@@ -131,7 +131,7 @@ class XMLToDictTestCase(unittest.TestCase):
         self.assertEqual(parser(xml), expectedResult)
         rv = parser(xml, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv.has_xml_attrs())
 
     def test_custom_cdata(self):
         xml = '<a>data</a>'
@@ -141,7 +141,7 @@ class XMLToDictTestCase(unittest.TestCase):
         self.assertEqual(parser(xml), expectedResult)
         rv = parser(xml, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv.has_xml_attrs())
 
     def test_list(self):
         xml = '<a><b>1</b><b>2</b><b>3</b></a>'
@@ -150,7 +150,7 @@ class XMLToDictTestCase(unittest.TestCase):
         self.assertEqual(self.parse(xml), expectedResult)
         rv = self.parse(xml, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv.has_xml_attrs())
 
     def test_attrib_root(self):
         xml = '<a href="xyz"/>'
@@ -159,10 +159,10 @@ class XMLToDictTestCase(unittest.TestCase):
                          {'a': {'@href': 'xyz'}})
         rv = self.parse(xml, new_style=True)
         self.assertEqual(rv, {'a': ''})
-        self.assertFalse(rv.hasXMLattributes())
-        self.assertTrue(rv['a'].hasXMLattributes())
-        self.assertEqual(rv['a'].getXMLattribute("href", None), 'xyz')
-        self.assertEqual(rv['a'].getXMLattributes(), {'href': 'xyz'})
+        self.assertFalse(rv.has_xml_attrs())
+        self.assertTrue(rv['a'].has_xml_attrs())
+        self.assertEqual(rv['a'].get_xml_attr("href", None), 'xyz')
+        self.assertEqual(rv['a'].get_xml_attrs(), {'href': 'xyz'})
 
     def test_attrib_leaf(self):
         xml = '<root><a href="xyz"/></root>'
@@ -171,12 +171,12 @@ class XMLToDictTestCase(unittest.TestCase):
                          {'root': {'a': {'@href': 'xyz'}}})
         rv = self.parse(xml, new_style=True)
         self.assertEqual(rv, {'root': {'a': ''}})
-        self.assertFalse(rv.hasXMLattributes())
-        self.assertFalse(rv['root'].hasXMLattributes())
+        self.assertFalse(rv.has_xml_attrs())
+        self.assertFalse(rv['root'].has_xml_attrs())
         nodea = rv['root']['a']
-        self.assertTrue(nodea.hasXMLattributes())
-        self.assertEqual(nodea.getXMLattribute("href", None), 'xyz')
-        self.assertEqual(nodea.getXMLattributes(), {'href': 'xyz'})
+        self.assertTrue(nodea.has_xml_attrs())
+        self.assertEqual(nodea.get_xml_attr("href", None), 'xyz')
+        self.assertEqual(nodea.get_xml_attrs(), {'href': 'xyz'})
 
     def test_skip_attrib(self):
         xml = '<a href="xyz"/>'
@@ -186,7 +186,7 @@ class XMLToDictTestCase(unittest.TestCase):
         self.assertEqual(parser(xml), expectedResult)
         rv = parser(xml, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv.has_xml_attrs())
 
     def test_custom_attrib(self):
         xml = '<a href="xyz"/>'
@@ -196,9 +196,9 @@ class XMLToDictTestCase(unittest.TestCase):
                          {'a': {'!href': 'xyz'}})
         rv = parser(xml, new_style=True)
         self.assertEqual(rv, {'a': ''})
-        self.assertFalse(rv.hasXMLattributes())
-        self.assertTrue(rv['a'].hasXMLattributes())
-        self.assertEqual(rv['a'].getXMLattributes(),
+        self.assertFalse(rv.has_xml_attrs())
+        self.assertTrue(rv['a'].has_xml_attrs())
+        self.assertEqual(rv['a'].get_xml_attrs(),
                          {'!href': 'xyz'})
 
     def test_attrib_and_cdata(self):
@@ -208,9 +208,9 @@ class XMLToDictTestCase(unittest.TestCase):
                          {'a': {'@href': 'xyz', '#text': '123'}})
         rv = self.parse(xml, new_style=True)
         self.assertEqual(rv, {'a': '123'})
-        self.assertFalse(rv.hasXMLattributes())
-        self.assertTrue(rv['a'].hasXMLattributes())
-        self.assertEqual(rv['a'].getXMLattributes(),
+        self.assertFalse(rv.has_xml_attrs())
+        self.assertTrue(rv['a'].has_xml_attrs())
+        self.assertEqual(rv['a'].get_xml_attrs(),
                          {'href': 'xyz'})
 
     def test_semi_structured(self):
@@ -257,11 +257,11 @@ class XMLToDictTestCase(unittest.TestCase):
             {'root': {'emptya': None,
                       'emptyb': '',
                       'value': 'hello'}})
-        self.assertFalse(rv.hasXMLattributes())
-        self.assertFalse(rv['root'].hasXMLattributes())
-        self.assertFalse(rv['root']['value'].hasXMLattributes())
-        self.assertTrue(rv['root']['emptyb'].hasXMLattributes())
-        self.assertEqual(rv['root']['emptyb'].getXMLattributes(),
+        self.assertFalse(rv.has_xml_attrs())
+        self.assertFalse(rv['root'].has_xml_attrs())
+        self.assertFalse(rv['root']['value'].has_xml_attrs())
+        self.assertTrue(rv['root']['emptyb'].has_xml_attrs())
+        self.assertEqual(rv['root']['emptyb'].get_xml_attrs(),
                          {'attr': 'attrvalue'})
 
     def test_keep_whitespace(self):
@@ -454,12 +454,12 @@ class XMLToDictTestCase(unittest.TestCase):
         }
         rv = parser(xml, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
-        self.assertFalse(rv['http://defaultns.com/:root'].hasXMLattributes())
-        self.assertFalse(rv['http://defaultns.com/:root']['http://a.com/:y'].hasXMLattributes())
-        self.assertFalse(rv['http://defaultns.com/:root']['http://b.com/:z'].hasXMLattributes())
+        self.assertFalse(rv.has_xml_attrs())
+        self.assertFalse(rv['http://defaultns.com/:root'].has_xml_attrs())
+        self.assertFalse(rv['http://defaultns.com/:root']['http://a.com/:y'].has_xml_attrs())
+        self.assertFalse(rv['http://defaultns.com/:root']['http://b.com/:z'].has_xml_attrs())
         self.assertEqual(
-            rv['http://defaultns.com/:root']['http://defaultns.com/:x'].getXMLattributes(),
+            rv['http://defaultns.com/:root']['http://defaultns.com/:x'].get_xml_attrs(),
             {'http://a.com/:attr': 'val'})
 
     def test_namespace_collapse(self):
@@ -498,12 +498,12 @@ class XMLToDictTestCase(unittest.TestCase):
         }
         rv = parser(xml, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
-        self.assertFalse(rv['root'].hasXMLattributes())
-        self.assertFalse(rv['root']['ns_a:y'].hasXMLattributes())
-        self.assertFalse(rv['root']['http://b.com/:z'].hasXMLattributes())
-        self.assertTrue(rv['root']['x'].hasXMLattributes())
-        self.assertEqual(rv['root']['x'].getXMLattributes(),
+        self.assertFalse(rv.has_xml_attrs())
+        self.assertFalse(rv['root'].has_xml_attrs())
+        self.assertFalse(rv['root']['ns_a:y'].has_xml_attrs())
+        self.assertFalse(rv['root']['http://b.com/:z'].has_xml_attrs())
+        self.assertTrue(rv['root']['x'].has_xml_attrs())
+        self.assertEqual(rv['root']['x'].get_xml_attrs(),
                          {'ns_a:attr': 'val'})
 
     def translate_namespace(self, root, ns_map, _inherited_ns={}, force_cdata=False):
@@ -544,7 +544,7 @@ class XMLToDictTestCase(unittest.TestCase):
             else:
                 rv = dict()
         if isinstance(root, xmltodict.XMLCDATANode) or isinstance(root, xmltodict.XMLDictNode):
-            for (k,v) in root.getXMLattributes().items():
+            for (k,v) in root.get_xml_attrs().items():
                 items.append(("@" + k, v))
 
         for (k,v) in items:
@@ -568,8 +568,8 @@ class XMLToDictTestCase(unittest.TestCase):
                                 new_ns[""] = childV
                             else:
                                 new_ns[childK[index+1:]] = childV
-                if hasattr(child, "getXMLattributes"):
-                    for (childK, childV) in child.getXMLattributes().items():
+                if hasattr(child, "get_xml_attrs"):
+                    for (childK, childV) in child.get_xml_attrs().items():
                         if childK.startswith("xmlns"):
                             index = childK.rfind(":")
                             if index < 0:
@@ -602,7 +602,7 @@ class XMLToDictTestCase(unittest.TestCase):
 
                 # Build the entry
                 if (isinstance(rv, xmltodict.XMLDictNode) or isinstance(rv, xmltodict.XMLCDATANode)) and k[0] == "@":
-                    rv.setXMLattribute(newtag, v)
+                    rv.set_xml_attr(newtag, v)
                 else:
                     if k[0] == "@":
                         newtag = "@" + newtag
@@ -614,9 +614,9 @@ class XMLToDictTestCase(unittest.TestCase):
         # it.
         if isinstance(rv, dict) and list(rv.keys()) == ['#text'] and (not force_cdata):
             if isinstance(rv, xmltodict.XMLDictNode):
-                newAttrs = rv.getXMLattributes()
-                newAttrs.update(rv['#text'].getXMLattributes())
-                rv['#text'].XMLattrs = newAttrs
+                newAttrs = rv.get_xml_attrs()
+                newAttrs.update(rv['#text'].get_xml_attrs())
+                rv['#text'].xml_attrs = newAttrs
             return rv['#text']
         return rv
 
@@ -661,10 +661,10 @@ class XMLToDictTestCase(unittest.TestCase):
                         expectedResult['root'][k] = expectedResult['root'][k]['#text']
             rv = self.parse(xml, new_style=True)
             self.assertEqual(rv, expectedResult)
-            self.assertEqual(rv['root'].getXMLattributes(),
+            self.assertEqual(rv['root'].get_xml_attrs(),
                              expectedAttributes.pop('root'))
             for k in expectedAttributes.keys():
-                self.assertEqual(rv['root'][k].getXMLattributes(),
+                self.assertEqual(rv['root'][k].get_xml_attrs(),
                                  expectedAttributes[k])
         else:
             # Here, the NS identifiers may be different because they
@@ -686,20 +686,20 @@ class XMLToDictTestCase(unittest.TestCase):
                                           ns_map)
             for (k,v) in list(expectedResult['root'].items()):
                 if k.startswith("@"):
-                    self.assertEqual(rv['root'].getXMLattribute(k[1:]),
+                    self.assertEqual(rv['root'].get_xml_attr(k[1:]),
                                      expectedResult['root'].pop(k))
                 elif isinstance(v, dict):
                     for childK in list(expectedResult['root'][k].keys()):
                         if childK.startswith("@"):
                             self.assertTrue(
-                                childK[1:] in rv['root'][k].getXMLattributes(),
+                                childK[1:] in rv['root'][k].get_xml_attrs(),
                                 msg="%s attribute not in attribute store %r" % (
                                     childK[1:],
-                                    rv['root'][k].getXMLattributes()
+                                    rv['root'][k].get_xml_attrs()
                                 )
                             )
                             self.assertEqual(
-                                rv['root'][k].getXMLattribute(childK[1:]),
+                                rv['root'][k].get_xml_attr(childK[1:]),
                                 expectedResult['root'][k].pop(childK),
                             )
                     if list(expectedResult['root'][k].keys()) == ['#text']:
@@ -728,10 +728,10 @@ class XMLToDictTestCase(unittest.TestCase):
         self.assertEqual(parser(xml), expectedResult)
         rv = parser(xml, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
-        self.assertFalse(rv['root'].hasXMLattributes())
+        self.assertFalse(rv.has_xml_attrs())
+        self.assertFalse(rv['root'].has_xml_attrs())
         for k in rv['root'].keys():
-            self.assertFalse(rv['root'][k].hasXMLattributes())
+            self.assertFalse(rv['root'][k].has_xml_attrs())
 
     def test_namespace_strip_attributes_positive(self):
         xml = """
@@ -769,12 +769,12 @@ class XMLToDictTestCase(unittest.TestCase):
         }
         rv = parser(xml, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
-        self.assertFalse(rv['root'].hasXMLattributes())
-        self.assertFalse(rv['root']['x'].hasXMLattributes())
-        self.assertEqual(rv['root']['y'].getXMLattributes(),
+        self.assertFalse(rv.has_xml_attrs())
+        self.assertFalse(rv['root'].has_xml_attrs())
+        self.assertFalse(rv['root']['x'].has_xml_attrs())
+        self.assertEqual(rv['root']['y'].get_xml_attrs(),
                          {'a': 'val'})
-        self.assertEqual(rv['root']['z'].getXMLattributes(),
+        self.assertEqual(rv['root']['z'].get_xml_attrs(),
                          {'a': 'val1', 'b': 'val2'})
 
     def test_namespace_strip_attributes_negative(self):
@@ -813,12 +813,12 @@ class XMLToDictTestCase(unittest.TestCase):
         }
         rv = self.parse(xml, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
-        self.assertFalse(rv['root'].hasXMLattributes())
-        self.assertTrue(rv['root']['x'].hasXMLattributes())
-        self.assertEqual(rv['root']['x'].getXMLattribute('a'), "val1")
-        self.assertEqual(rv['root']['x'].getXMLattribute('b', '@@@@'), '@@@@')
-        self.assertRaises(KeyError, rv['root']['x'].getXMLattribute, 'b')
+        self.assertFalse(rv.has_xml_attrs())
+        self.assertFalse(rv['root'].has_xml_attrs())
+        self.assertTrue(rv['root']['x'].has_xml_attrs())
+        self.assertEqual(rv['root']['x'].get_xml_attr('a'), "val1")
+        self.assertEqual(rv['root']['x'].get_xml_attr('b', '@@@@'), '@@@@')
+        self.assertRaises(KeyError, rv['root']['x'].get_xml_attr, 'b')
 
     def test_newstyle_xmlattribute_set(self):
         xml = """
@@ -834,23 +834,23 @@ class XMLToDictTestCase(unittest.TestCase):
         }
         rv = self.parse(xml, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
-        self.assertFalse(rv['root'].hasXMLattributes())
-        self.assertTrue(rv['root']['x'].hasXMLattributes())
-        self.assertEqual(rv['root']['x'].getXMLattribute('a'), "val1")
-        rv['root']['x'].setXMLattribute('a', "val2")
-        self.assertEqual(rv['root']['x'].getXMLattribute('a'), "val2")
-        self.assertRaises(KeyError, rv['root']['x'].getXMLattribute, 'b')
-        rv['root']['x'].setXMLattribute('b', "val3")
-        self.assertEqual(rv['root']['x'].getXMLattribute('a'), "val2")
-        self.assertEqual(rv['root']['x'].getXMLattribute('b'), "val3")
-        self.assertEqual(rv['root']['x'].getXMLattributes(),
+        self.assertFalse(rv.has_xml_attrs())
+        self.assertFalse(rv['root'].has_xml_attrs())
+        self.assertTrue(rv['root']['x'].has_xml_attrs())
+        self.assertEqual(rv['root']['x'].get_xml_attr('a'), "val1")
+        rv['root']['x'].set_xml_attr('a', "val2")
+        self.assertEqual(rv['root']['x'].get_xml_attr('a'), "val2")
+        self.assertRaises(KeyError, rv['root']['x'].get_xml_attr, 'b')
+        rv['root']['x'].set_xml_attr('b', "val3")
+        self.assertEqual(rv['root']['x'].get_xml_attr('a'), "val2")
+        self.assertEqual(rv['root']['x'].get_xml_attr('b'), "val3")
+        self.assertEqual(rv['root']['x'].get_xml_attrs(),
                          {'a': "val2", 'b': "val3"})
-        self.assertEqual(rv['root'].getXMLattributes(), dict())
-        rv['root'].setXMLattribute('newattrib', "@@@")
-        self.assertTrue(rv['root'].hasXMLattributes())
-        self.assertEqual(rv['root'].getXMLattribute('newattrib'), "@@@")
-        self.assertEqual(rv['root'].getXMLattributes(),
+        self.assertEqual(rv['root'].get_xml_attrs(), dict())
+        rv['root'].set_xml_attr('newattrib', "@@@")
+        self.assertTrue(rv['root'].has_xml_attrs())
+        self.assertEqual(rv['root'].get_xml_attr('newattrib'), "@@@")
+        self.assertEqual(rv['root'].get_xml_attrs(),
                          {'newattrib': "@@@"})
 
     def test_newstyle_xmlattribute_delete(self):
@@ -867,19 +867,19 @@ class XMLToDictTestCase(unittest.TestCase):
         }
         rv = self.parse(xml, new_style=True)
         self.assertEqual(rv, expectedResult)
-        self.assertFalse(rv.hasXMLattributes())
-        self.assertFalse(rv['root'].hasXMLattributes())
-        self.assertTrue(rv['root']['x'].hasXMLattributes())
-        self.assertEqual(rv['root']['x'].getXMLattribute('a'), "val1")
-        self.assertEqual(rv['root']['x'].getXMLattributes(),
+        self.assertFalse(rv.has_xml_attrs())
+        self.assertFalse(rv['root'].has_xml_attrs())
+        self.assertTrue(rv['root']['x'].has_xml_attrs())
+        self.assertEqual(rv['root']['x'].get_xml_attr('a'), "val1")
+        self.assertEqual(rv['root']['x'].get_xml_attrs(),
                          {'a': "val1"})
-        self.assertRaises(KeyError, rv['root']['x'].delXMLattribute,
+        self.assertRaises(KeyError, rv['root']['x'].delete_xml_attr,
                           'b')
-        self.assertEqual(rv['root']['x'].getXMLattributes(),
+        self.assertEqual(rv['root']['x'].get_xml_attrs(),
                          {'a': "val1"})
-        rv['root']['x'].delXMLattribute('a')
-        self.assertFalse(rv['root']['x'].hasXMLattributes())
-        self.assertEqual(rv['root']['x'].getXMLattributes(), dict())
+        rv['root']['x'].delete_xml_attr('a')
+        self.assertFalse(rv['root']['x'].has_xml_attrs())
+        self.assertEqual(rv['root']['x'].get_xml_attrs(), dict())
 
     def test_key_promotion_with_compress(self):
         xml = """

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -146,11 +146,11 @@ class XMLToDictTestCase(unittest.TestCase):
         self.assertEqual(self.parse(xml),
                          {'a': {'@href': 'xyz'}})
         rv = self.parse(xml, new_style=True)
-        self.assertEqual(rv, {u'a': ''})
+        self.assertEqual(rv, {'a': ''})
         self.assertFalse(rv.hasXMLattributes())
         self.assertTrue(rv['a'].hasXMLattributes())
         self.assertEqual(rv['a'].getXMLattribute("href", None), 'xyz')
-        self.assertEqual(rv['a'].getXMLattributes(), {u'href': 'xyz'})
+        self.assertEqual(rv['a'].getXMLattributes(), {'href': 'xyz'})
 
     def test_attrib_leaf(self):
         xml = '<root><a href="xyz"/></root>'
@@ -158,13 +158,13 @@ class XMLToDictTestCase(unittest.TestCase):
         self.assertEqual(self.parse(xml),
                          {'root': {'a': {'@href': 'xyz'}}})
         rv = self.parse(xml, new_style=True)
-        self.assertEqual(rv, {'root': {u'a': ''}})
+        self.assertEqual(rv, {'root': {'a': ''}})
         self.assertFalse(rv.hasXMLattributes())
         self.assertFalse(rv['root'].hasXMLattributes())
         nodea = rv['root']['a']
         self.assertTrue(nodea.hasXMLattributes())
         self.assertEqual(nodea.getXMLattribute("href", None), 'xyz')
-        self.assertEqual(nodea.getXMLattributes(), {u'href': 'xyz'})
+        self.assertEqual(nodea.getXMLattributes(), {'href': 'xyz'})
 
     def test_skip_attrib(self):
         xml = '<a href="xyz"/>'
@@ -1193,20 +1193,20 @@ class NewStyleClassTestCase(unittest.TestCase):
         self.assertEqual(ioObj1.getvalue(), ioObj2.getvalue())
 
     def test_newstyle_prettyprint(self):
-        data1_orig = u"data1"
+        data1_orig = "data1"
         data1 = xmltodict.XMLCDATANode(data1_orig)
-        data2_orig = u"data2"
+        data2_orig = "data2"
         data2 = xmltodict.XMLCDATANode(data2_orig)
         list1_orig = [data1_orig, data2_orig]
         list1 = xmltodict.XMLListNode((data1, data2))
-        nodec = xmltodict.XMLDictNode({u'c': list1})
-        nodeb = xmltodict.XMLDictNode({u'b': nodec})
-        nodea = xmltodict.XMLDictNode({u'a': nodeb})
+        nodec = xmltodict.XMLDictNode({'c': list1})
+        nodeb = xmltodict.XMLDictNode({'b': nodec})
+        nodea = xmltodict.XMLDictNode({'a': nodeb})
 
         for depth in (None, 1, 2, 3, 4, 5):
             #dict level
             self.pprint_compare(nodea,
-                                {u'a': {u'b': {u'c': list1_orig}}},
+                                {'a': {'b': {'c': list1_orig}}},
                                 depth=depth)
 
             # list level
@@ -1218,6 +1218,6 @@ class NewStyleClassTestCase(unittest.TestCase):
         # Check non-XML*Node elements under an XML*Node element
         list1 = xmltodict.XMLListNode((data1, data2_orig))
         self.pprint_compare(list1, list1_orig)
-        nodec[u'd'] = data2_orig
+        nodec['d'] = data2_orig
         self.pprint_compare(nodec,
-                            {u'c': list1_orig, u'd': data2_orig})
+                            {'c': list1_orig, 'd': data2_orig})

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -360,9 +360,14 @@ class XMLToDictTestCase(unittest.TestCase):
         # values as expected.
         parser = self.Parser(generator=True, item_depth=2)
         fileio_values = list()
+        num_iterations = 0
         for (item, value) in parser(ioObj):
-            if len(fileio_values) < 10:
-                self.assertTrue(ioObj.bytes_read < len(xml))
+            num_iterations += 1
+            if num_iterations <= 10:
+                self.assertTrue(
+                    ioObj.bytes_read < len(xml),
+                    msg="Bytes read (%d) is not less than the length of the full XML document (%d)" % (ioObj.bytes_read, len(xml))
+                )
             if item == expected_stack:
                 fileio_values.append(value)
 

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -1,4 +1,5 @@
-from xmltodict import parse, ParsingInterrupted
+from xmltodict import parse, Parser, parse_lxml, LXMLParser, ParsingInterrupted
+import xmltodict
 
 try:
     import unittest2 as unittest
@@ -16,66 +17,207 @@ def _encode(s):
     except (NameError, TypeError):
         return s
 
+if not hasattr(unittest.TestCase, "assertIsInstance"):
+    need_assertIsInstance = True
+else:
+    need_assertIsInstance = False
+
+if not hasattr(unittest.TestCase, "assertIsNotInstance"):
+    need_assertIsNotInstance = True
+else:
+    need_assertIsNotInstance = False
 
 class XMLToDictTestCase(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        self.parse = parse
+        self.Parser = Parser
+
+    if need_assertIsInstance:
+        def assertIsInstance(self, a, b, msg=None):
+            self.assertTrue(isinstance(a, b), msg=msg)
+
+    if need_assertIsNotInstance:
+        def assertIsNotInstance(self, a, b, msg=None):
+            self.assertFalse(isinstance(a, b), msg=msg)
+
+    def xmlTextToTestFormat(self, xml):
+        return xml
+
+    def test_parse_class(self):
+        xml = '<a>data</a>'
+        xml = self.xmlTextToTestFormat(xml)
+        parser = self.Parser()
+        self.assertIsInstance(parser, self.Parser)
+        rv = parser(xml)
+        self.assertIsInstance(rv, dict)
+        self.assertIsNotInstance(rv, xmltodict.XMLDictNode)
+        self.assertEqual(rv, {'a': 'data'})
+        rv = parser(xml, new_style=True)
+        self.assertIsInstance(rv, xmltodict.XMLDictNode)
+        self.assertEqual(rv, {'a': 'data'})
+
+    def test_parse_class_defaults(self):
+        xml = '<a>data</a>'
+        xml = self.xmlTextToTestFormat(xml)
+        parser = self.Parser(force_cdata=True)
+        self.assertEqual(parser(xml), {'a': {'#text': 'data'}})
+        self.assertEqual(parser(xml, force_cdata=False),
+                         {'a': 'data'})
+        self.assertEqual(parser(xml), {'a': {'#text': 'data'}})
 
     def test_string_vs_file(self):
         xml = '<a>data</a>'
-        self.assertEqual(parse(xml),
-                         parse(StringIO(_encode(xml))))
+        xml = self.xmlTextToTestFormat(xml)
+        self.assertEqual(self.parse(xml),
+                         self.parse(StringIO(_encode(xml))))
 
     def test_minimal(self):
-        self.assertEqual(parse('<a/>'),
-                         {'a': None})
-        self.assertEqual(parse('<a/>', force_cdata=True),
-                         {'a': None})
+        xml = '<a/>'
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {'a': None}
+        self.assertEqual(self.parse(xml), expectedResult)
+        self.assertEqual(self.parse(xml, force_cdata=True),
+                         expectedResult)
+        rv = self.parse(xml, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
+        rv = self.parse(xml, force_cdata=True, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
 
     def test_simple(self):
-        self.assertEqual(parse('<a>data</a>'),
-                         {'a': 'data'})
+        xml = '<a>data</a>'
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {'a': 'data'}
+        self.assertEqual(self.parse(xml), expectedResult)
+        rv = self.parse(xml, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
+        self.assertEqual(rv.getXMLattributes(), {})
+
+    def test_list_simple(self):
+        xml = '<a><b>data1</b><b>data2</b></a>'
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {'a': {'b': ['data1', 'data2']}}
+        self.assertEqual(self.parse(xml), expectedResult)
+        rv = self.parse(xml, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
+        self.assertEqual(rv.getXMLattributes(), {})
+        self.assertFalse(rv['a'].hasXMLattributes())
+        self.assertFalse(rv['a']['b'].hasXMLattributes())
+        self.assertFalse(rv['a']['b'][0].hasXMLattributes())
+        self.assertFalse(rv['a']['b'][1].hasXMLattributes())
 
     def test_force_cdata(self):
-        self.assertEqual(parse('<a>data</a>', force_cdata=True),
-                         {'a': {'#text': 'data'}})
+        xml = '<a>data</a>'
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {'a': {'#text': 'data'}}
+        parser = self.Parser(force_cdata=True)
+        self.assertEqual(parser(xml), expectedResult)
+        rv = parser(xml, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
 
     def test_custom_cdata(self):
-        self.assertEqual(parse('<a>data</a>',
-                               force_cdata=True,
-                               cdata_key='_CDATA_'),
-                         {'a': {'_CDATA_': 'data'}})
+        xml = '<a>data</a>'
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {'a': {'_CDATA_': 'data'}}
+        parser = self.Parser(force_cdata=True, cdata_key='_CDATA_')
+        self.assertEqual(parser(xml), expectedResult)
+        rv = parser(xml, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
 
     def test_list(self):
-        self.assertEqual(parse('<a><b>1</b><b>2</b><b>3</b></a>'),
-                         {'a': {'b': ['1', '2', '3']}})
+        xml = '<a><b>1</b><b>2</b><b>3</b></a>'
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {'a': {'b': ['1', '2', '3']}}
+        self.assertEqual(self.parse(xml), expectedResult)
+        rv = self.parse(xml, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
 
-    def test_attrib(self):
-        self.assertEqual(parse('<a href="xyz"/>'),
+    def test_attrib_root(self):
+        xml = '<a href="xyz"/>'
+        xml = self.xmlTextToTestFormat(xml)
+        self.assertEqual(self.parse(xml),
                          {'a': {'@href': 'xyz'}})
+        rv = self.parse(xml, new_style=True)
+        self.assertEqual(rv, {u'a': ''})
+        self.assertFalse(rv.hasXMLattributes())
+        self.assertTrue(rv['a'].hasXMLattributes())
+        self.assertEqual(rv['a'].getXMLattribute("href", None), 'xyz')
+        self.assertEqual(rv['a'].getXMLattributes(), {u'href': 'xyz'})
+
+    def test_attrib_leaf(self):
+        xml = '<root><a href="xyz"/></root>'
+        xml = self.xmlTextToTestFormat(xml)
+        self.assertEqual(self.parse(xml),
+                         {'root': {'a': {'@href': 'xyz'}}})
+        rv = self.parse(xml, new_style=True)
+        self.assertEqual(rv, {'root': {u'a': ''}})
+        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv['root'].hasXMLattributes())
+        nodea = rv['root']['a']
+        self.assertTrue(nodea.hasXMLattributes())
+        self.assertEqual(nodea.getXMLattribute("href", None), 'xyz')
+        self.assertEqual(nodea.getXMLattributes(), {u'href': 'xyz'})
 
     def test_skip_attrib(self):
-        self.assertEqual(parse('<a href="xyz"/>', xml_attribs=False),
-                         {'a': None})
+        xml = '<a href="xyz"/>'
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {'a': None}
+        parser = self.Parser(xml_attribs=False)
+        self.assertEqual(parser(xml), expectedResult)
+        rv = parser(xml, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
 
     def test_custom_attrib(self):
-        self.assertEqual(parse('<a href="xyz"/>',
-                               attr_prefix='!'),
+        xml = '<a href="xyz"/>'
+        xml = self.xmlTextToTestFormat(xml)
+        parser = self.Parser(attr_prefix='!')
+        self.assertEqual(parser(xml),
                          {'a': {'!href': 'xyz'}})
+        rv = parser(xml, new_style=True)
+        self.assertEqual(rv, {'a': ''})
+        self.assertFalse(rv.hasXMLattributes())
+        self.assertTrue(rv['a'].hasXMLattributes())
+        self.assertEqual(rv['a'].getXMLattributes(),
+                         {'!href': 'xyz'})
 
     def test_attrib_and_cdata(self):
-        self.assertEqual(parse('<a href="xyz">123</a>'),
+        xml = '<a href="xyz">123</a>'
+        xml = self.xmlTextToTestFormat(xml)
+        self.assertEqual(self.parse(xml),
                          {'a': {'@href': 'xyz', '#text': '123'}})
+        rv = self.parse(xml, new_style=True)
+        self.assertEqual(rv, {'a': '123'})
+        self.assertFalse(rv.hasXMLattributes())
+        self.assertTrue(rv['a'].hasXMLattributes())
+        self.assertEqual(rv['a'].getXMLattributes(),
+                         {'href': 'xyz'})
 
     def test_semi_structured(self):
-        self.assertEqual(parse('<a>abc<b/>def</a>'),
-                         {'a': {'b': None, '#text': 'abcdef'}})
-        self.assertEqual(parse('<a>abc<b/>def</a>',
-                               cdata_separator='\n'),
-                         {'a': {'b': None, '#text': 'abc\ndef'}})
+        xml = '<a>abc<b/>def</a>'
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {'a': {'b': None, '#text': 'abcdef'}}
+        self.assertEqual(self.parse(xml), expectedResult)
+        self.assertEqual(self.parse(xml, new_style=True), expectedResult)
+        expectedResult = {'a': {'b': None, '#text': 'abc\ndef'}}
+        parser = self.Parser(cdata_separator='\n')
+        self.assertEqual(parser(xml), expectedResult)
+        self.assertEqual(parser(xml, new_style=True), expectedResult)
 
     def test_nested_semi_structured(self):
-        self.assertEqual(parse('<a>abc<b>123<c/>456</b>def</a>'),
-                         {'a': {'#text': 'abcdef', 'b': {
-                             '#text': '123456', 'c': None}}})
+        xml = '<a>abc<b>123<c/>456</b>def</a>'
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {'a': {'#text': 'abcdef', 'b': {
+            '#text': '123456', 'c': None}}}
+        self.assertEqual(self.parse(xml), expectedResult)
+        self.assertEqual(self.parse(xml, new_style=True), expectedResult)
 
     def test_skip_whitespace(self):
         xml = """
@@ -90,17 +232,33 @@ class XMLToDictTestCase(unittest.TestCase):
           <value>hello</value>
         </root>
         """
+        xml = self.xmlTextToTestFormat(xml)
         self.assertEqual(
-            parse(xml),
+            self.parse(xml),
             {'root': {'emptya': None,
                       'emptyb': {'@attr': 'attrvalue'},
                       'value': 'hello'}})
+        rv = self.parse(xml, new_style=True)
+        self.assertEqual(
+            rv,
+            {'root': {'emptya': None,
+                      'emptyb': '',
+                      'value': 'hello'}})
+        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv['root'].hasXMLattributes())
+        self.assertFalse(rv['root']['value'].hasXMLattributes())
+        self.assertTrue(rv['root']['emptyb'].hasXMLattributes())
+        self.assertEqual(rv['root']['emptyb'].getXMLattributes(),
+                         {'attr': 'attrvalue'})
 
     def test_keep_whitespace(self):
         xml = "<root> </root>"
-        self.assertEqual(parse(xml), dict(root=None))
-        self.assertEqual(parse(xml, strip_whitespace=False),
-                         dict(root=' '))
+        xml = self.xmlTextToTestFormat(xml)
+        self.assertEqual(self.parse(xml), dict(root=None))
+        self.assertEqual(self.parse(xml, new_style=True), dict(root=None))
+        parser = self.Parser(strip_whitespace=False)
+        self.assertEqual(parser(xml), dict(root=' '))
+        self.assertEqual(parser(xml, new_style=True), dict(root=' '))
 
     def test_streaming(self):
         def cb(path, item):
@@ -108,9 +266,14 @@ class XMLToDictTestCase(unittest.TestCase):
             self.assertEqual(path, [('a', {'x': 'y'}), ('b', None)])
             self.assertEqual(item, str(cb.count))
             return True
+        xml = '<a x="y"><b>1</b><b>2</b><b>3</b></a>'
+        xml = self.xmlTextToTestFormat(xml)
+        parser = self.Parser(item_depth=2, item_callback=cb)
         cb.count = 0
-        parse('<a x="y"><b>1</b><b>2</b><b>3</b></a>',
-              item_depth=2, item_callback=cb)
+        parser(xml)
+        self.assertEqual(cb.count, 3)
+        cb.count = 0
+        parser(xml, new_style=True)
         self.assertEqual(cb.count, 3)
 
     def test_streaming_interrupt(self):
@@ -125,9 +288,12 @@ class XMLToDictTestCase(unittest.TestCase):
                 return key + ':int', int(value)
             except (ValueError, TypeError):
                 return key, value
-        self.assertEqual({'a': {'b:int': [1, 2], 'b': 'x'}},
-                         parse('<a><b>1</b><b>2</b><b>x</b></a>',
-                               postprocessor=postprocessor))
+        xml = '<a><b>1</b><b>2</b><b>x</b></a>'
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {'a': {'b:int': [1, 2], 'b': 'x'}}
+        parser = self.Parser(postprocessor=postprocessor)
+        self.assertEqual(parser(xml), expectedResult)
+        self.assertEqual(parser(xml, new_style=True), expectedResult)
 
     def test_postprocessor_skip(self):
         def postprocessor(path, key, value):
@@ -136,17 +302,23 @@ class XMLToDictTestCase(unittest.TestCase):
                 if value == 3:
                     return None
             return key, value
-        self.assertEqual({'a': {'b': [1, 2]}},
-                         parse('<a><b>1</b><b>2</b><b>3</b></a>',
-                               postprocessor=postprocessor))
+        xml = '<a><b>1</b><b>2</b><b>3</b></a>'
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {'a': {'b': [1, 2]}}
+        parser = self.Parser(postprocessor=postprocessor)
+        self.assertEqual(parser(xml), expectedResult)
+        self.assertEqual(parser(xml, new_style=True), expectedResult)
 
     def test_unicode(self):
         try:
             value = unichr(39321)
         except NameError:
             value = chr(39321)
-        self.assertEqual({'a': value},
-                         parse('<a>%s</a>' % value))
+        xml = '<a>%s</a>' % value
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {'a': value}
+        self.assertEqual(self.parse(xml), expectedResult)
+        self.assertEqual(self.parse(xml, new_style=True), expectedResult)
 
     def test_encoded_string(self):
         try:
@@ -154,8 +326,13 @@ class XMLToDictTestCase(unittest.TestCase):
         except NameError:
             value = chr(39321)
         xml = '<a>%s</a>' % value
-        self.assertEqual(parse(xml),
-                         parse(xml.encode('utf-8')))
+        xml = self.xmlTextToTestFormat(xml)
+        if not (isinstance(xml, str) or isinstance(xml, unicode)):
+            raise unittest.SkipTest("Test only makes sense when parsing text.")
+        self.assertEqual(self.parse(xml),
+                         self.parse(xml.encode('utf-8')))
+        self.assertEqual(self.parse(xml, new_style=True),
+                         self.parse(xml.encode('utf-8'), new_style=True))
 
     def test_namespace_support(self):
         xml = """
@@ -167,7 +344,8 @@ class XMLToDictTestCase(unittest.TestCase):
           <b:z>3</b:z>
         </root>
         """
-        d = {
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
             'http://defaultns.com/:root': {
                 'http://defaultns.com/:x': {
                     '@http://a.com/:attr': 'val',
@@ -177,7 +355,24 @@ class XMLToDictTestCase(unittest.TestCase):
                 'http://b.com/:z': '3',
             }
         }
-        self.assertEqual(parse(xml, process_namespaces=True), d)
+        parser=self.Parser(process_namespaces=True)
+        self.assertEqual(parser(xml), expectedResult)
+        expectedResult = {
+            'http://defaultns.com/:root': {
+                'http://defaultns.com/:x': '1',
+                'http://a.com/:y': '2',
+                'http://b.com/:z': '3',
+            }
+        }
+        rv = parser(xml, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv['http://defaultns.com/:root'].hasXMLattributes())
+        self.assertFalse(rv['http://defaultns.com/:root']['http://a.com/:y'].hasXMLattributes())
+        self.assertFalse(rv['http://defaultns.com/:root']['http://b.com/:z'].hasXMLattributes())
+        self.assertEqual(
+            rv['http://defaultns.com/:root']['http://defaultns.com/:x'].getXMLattributes(),
+            {'http://a.com/:attr': 'val'})
 
     def test_namespace_collapse(self):
         xml = """
@@ -189,11 +384,12 @@ class XMLToDictTestCase(unittest.TestCase):
           <b:z>3</b:z>
         </root>
         """
+        xml = self.xmlTextToTestFormat(xml)
         namespaces = {
             'http://defaultns.com/': None,
             'http://a.com/': 'ns_a',
         }
-        d = {
+        expectedResult = {
             'root': {
                 'x': {
                     '@ns_a:attr': 'val',
@@ -203,10 +399,226 @@ class XMLToDictTestCase(unittest.TestCase):
                 'http://b.com/:z': '3',
             },
         }
-        self.assertEqual(
-            parse(xml, process_namespaces=True, namespaces=namespaces), d)
+        parser=self.Parser(process_namespaces=True, namespaces=namespaces)
+        self.assertEqual(parser(xml), expectedResult)
+        expectedResult = {
+            'root': {
+                'x': '1',
+                'ns_a:y': '2',
+                'http://b.com/:z': '3',
+            }
+        }
+        rv = parser(xml, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv['root'].hasXMLattributes())
+        self.assertFalse(rv['root']['ns_a:y'].hasXMLattributes())
+        self.assertFalse(rv['root']['http://b.com/:z'].hasXMLattributes())
+        self.assertTrue(rv['root']['x'].hasXMLattributes())
+        self.assertEqual(rv['root']['x'].getXMLattributes(),
+                         {'ns_a:attr': 'val'})
+
+    def translate_namespace(self, root, ns_map, _inherited_ns={}, force_cdata=False):
+        """
+        Recursively translate the namespace identifiers. Return a
+        new dictionary with the new namespace identifiers, but NO
+        xmlns attributes.
+
+        The initial callers hould NOT specify _inherited_ns. That
+        will be populated on recursive calls.
+
+        The initial caller should specify a `root`, which points to
+        the dictionary that contains the root node; and, the `ns_map`,
+        which is a dictionary with URLs as keys and NS identifiers
+        as values. (The default NS identifier should be specified as
+        "".)
+
+        KNOWN BUG: If the namespaces are defined in child nodes that
+        are in a list and the child nodes in the list have different
+        xmlns attributes, this may not work correctly.
+        """
+        if isinstance(root, list):
+            rv = list()
+            for v in root:
+                rv.append(self.translate_namespace(v, ns_map, _inherited_ns, force_cdata))
+            return rv
+
+        if not (isinstance(root, dict) or isinstance(root, xmltodict.XMLCDATANode)):
+            return root
+
+        if isinstance(root, xmltodict.XMLCDATANode):
+            items = []
+            rv = xmltodict.XMLCDATANode(root)
+        else:
+            items = root.items()
+            if isinstance(root, xmltodict.XMLDictNode):
+                rv = xmltodict.XMLDictNode()
+            else:
+                rv = dict()
+        if isinstance(root, xmltodict.XMLCDATANode) or isinstance(root, xmltodict.XMLDictNode):
+            for (k,v) in root.getXMLattributes().items():
+                items.append(("@" + k, v))
+
+        for (k,v) in items:
+            if k.startswith("@xmlns"):
+                pass
+            else:
+                new_ns = dict(_inherited_ns)
+                child = v
+
+                # This doesn't work quite right. Good enough for now.
+                while isinstance(child, list):
+                    child = child[0]
+
+                # Build a namespace dictionary for this node.
+                if isinstance(child, dict):
+                    for (childK, childV) in child.iteritems():
+                        if childK.startswith("@xmlns"):
+                            index = childK.rfind(":")
+                            if index < 0:
+                                self.assertEqual(childK, "@xmlns")
+                                new_ns[""] = childV
+                            else:
+                                new_ns[childK[index+1:]] = childV
+                if hasattr(child, "getXMLattributes"):
+                    for (childK, childV) in child.getXMLattributes().iteritems():
+                        if childK.startswith("xmlns"):
+                            index = childK.rfind(":")
+                            if index < 0:
+                                self.assertEqual(childK, "xmlns")
+                                new_ns[""] = childV
+                            else:
+                                new_ns[childK[index+1:]] = childV
+
+                # Translate the namespace for the tag, if necessary.
+                if k[0] == "@":
+                    basetag = k[1:]
+                else:
+                    basetag = k
+                index = basetag.rfind(":")
+                if index < 0:
+                    nsurl = new_ns.get("")
+                else:
+                    nsurl = new_ns.get(basetag[:index])
+                    self.assertTrue(
+                        nsurl,
+                        msg="Mapping for namespace \"%s\" not found" % (
+                            k[:index],
+                        ))
+                    basetag = basetag[index+1:]
+                if (not nsurl) or (not ns_map.get(nsurl, '@@NOMATCH@@')):
+                    newtag = basetag
+                else:
+                    self.assertTrue(nsurl in ns_map.iterkeys())
+                    newtag = ns_map[nsurl] + ":" + basetag
+
+                # Build the entry
+                if (isinstance(rv, xmltodict.XMLDictNode) or isinstance(rv, xmltodict.XMLCDATANode)) and k[0] == "@":
+                    rv.setXMLattribute(newtag, v)
+                else:
+                    if k[0] == "@":
+                        newtag = "@" + newtag
+                    rv[newtag] = self.translate_namespace(v, ns_map,
+                                                          new_ns,
+                                                          force_cdata)
+
+        # Special case: If all we are returning is a text node, promote
+        # it.
+        if isinstance(rv, dict) and rv.keys() == ['#text'] and (not force_cdata):
+            if isinstance(rv, xmltodict.XMLDictNode):
+                newAttrs = rv.getXMLattributes()
+                newAttrs.update(rv['#text'].getXMLattributes())
+                rv['#text'].XMLattrs = newAttrs
+            return rv['#text']
+        return rv
 
     def test_namespace_ignore(self):
+        xml = """
+        <root xmlns="http://defaultns.com/"
+              xmlns:a="http://a.com/"
+              xmlns:b="http://b.com/"
+              xmlns:c="http://c.com/">
+          <x>1</x>
+          <a:y c:attr="val">2</a:y>
+          <b:z>3</b:z>
+        </root>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'root': {
+                '@xmlns': 'http://defaultns.com/',
+                '@xmlns:a': 'http://a.com/',
+                '@xmlns:b': 'http://b.com/',
+                '@xmlns:c': 'http://c.com/',
+                'x': '1',
+                'a:y': {
+                    '@c:attr': 'val',
+                    '#text': '2',
+                },
+                'b:z': '3',
+            },
+        }
+        if isinstance(xml, str) or isinstance(xml, unicode) or hasattr(xml, "nsmap") or (hasattr(xml, "getroot") and hasattr(xml.getroot(), "nsmap")):
+            self.assertEqual(self.parse(xml), expectedResult)
+            expectedAttributes = dict(root={})
+            for (k,v) in expectedResult['root'].items():
+                if k.startswith("@"):
+                    expectedAttributes['root'][k[1:]] = expectedResult['root'].pop(k)
+                elif isinstance(v, dict):
+                    expectedAttributes[k]={}
+                    for childK in expectedResult['root'][k].keys():
+                        if childK.startswith("@"):
+                            expectedAttributes[k][childK[1:]] = expectedResult['root'][k].pop(childK)
+                    if len(expectedResult['root'][k]) == 1 and expectedResult['root'][k].keys() == ['#text']:
+                        expectedResult['root'][k] = expectedResult['root'][k]['#text']
+            rv = self.parse(xml, new_style=True)
+            self.assertEqual(rv, expectedResult)
+            self.assertEqual(rv['root'].getXMLattributes(),
+                             expectedAttributes.pop('root'))
+            for k in expectedAttributes.keys():
+                self.assertEqual(rv['root'][k].getXMLattributes(),
+                                 expectedAttributes[k])
+        else:
+            # Here, the NS identifiers may be different because they
+            # were lost during parsing.
+            # The key thing is that the NS relationships be the
+            # same.
+            ns_map = dict()
+            for k in expectedResult['root'].keys():
+                if k.startswith('@xmlns'):
+                    v = expectedResult['root'].pop(k)
+                    if k.rfind(":") >= 0:
+                        k = k[k.rfind(":")+1:]
+                    else:
+                        k = ""
+                    ns_map[v] = k
+            rv = self.translate_namespace(self.parse(xml), ns_map)
+            self.assertEqual(rv, expectedResult)
+            rv = self.translate_namespace(self.parse(xml, new_style=True),
+                                          ns_map)
+            for (k,v) in expectedResult['root'].items():
+                if k.startswith("@"):
+                    self.assertEqual(rv['root'].getXMLattribute(k[1:]),
+                                     expectedResult['root'].pop(k))
+                elif isinstance(v, dict):
+                    for childK in expectedResult['root'][k].keys():
+                        if childK.startswith("@"):
+                            self.assertTrue(
+                                rv['root'][k].getXMLattributes().has_key(childK[1:]),
+                                msg="%s attribute not in attribute store %r" % (
+                                    childK[1:],
+                                    rv['root'][k].getXMLattributes()
+                                )
+                            )
+                            self.assertEqual(
+                                rv['root'][k].getXMLattribute(childK[1:]),
+                                expectedResult['root'][k].pop(childK),
+                            )
+                    if len(expectedResult['root'][k]) == 1 and expectedResult['root'][k].has_key('#text'):
+                        expectedResult['root'][k] = expectedResult['root'][k]['#text']
+            self.assertEqual(rv, expectedResult)
+
+    def test_namespace_strip_basic(self):
         xml = """
         <root xmlns="http://defaultns.com/"
               xmlns:a="http://a.com/"
@@ -216,14 +628,594 @@ class XMLToDictTestCase(unittest.TestCase):
           <b:z>3</b:z>
         </root>
         """
-        d = {
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
             'root': {
-                '@xmlns': 'http://defaultns.com/',
-                '@xmlns:a': 'http://a.com/',
-                '@xmlns:b': 'http://b.com/',
                 'x': '1',
-                'a:y': '2',
-                'b:z': '3',
+                'y': '2',
+                'z': '3',
+            }
+        }
+        parser = self.Parser(strip_namespace=True)
+        self.assertEqual(parser(xml), expectedResult)
+        rv = parser(xml, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv['root'].hasXMLattributes())
+        for k in rv['root'].keys():
+            self.assertFalse(rv['root'][k].hasXMLattributes())
+
+    def test_namespace_strip_attributes_positive(self):
+        xml = """
+        <root xmlns="http://defaultns.com/"
+              xmlns:a="http://a.com/"
+              xmlns:b="http://b.com/">
+          <x>1</x>
+          <a:y a:a="val">2</a:y>
+          <b:z a="val1" a:b="val2">3</b:z>
+        </root>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'root': {
+                'x': '1',
+                'y': {
+                    '@a': 'val',
+                    '#text': '2',
+                },
+                'z': {
+                    '@a': 'val1',
+                    '@b': 'val2',
+                    '#text': '3',
+                },
+            }
+        }
+        parser = self.Parser(strip_namespace=True)
+        self.assertEqual(parser(xml), expectedResult)
+        expectedResult = {
+            'root': {
+                'x': '1',
+                'y': '2',
+                'z': '3',
+            }
+        }
+        rv = parser(xml, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv['root'].hasXMLattributes())
+        self.assertFalse(rv['root']['x'].hasXMLattributes())
+        self.assertEqual(rv['root']['y'].getXMLattributes(),
+                         {'a': 'val'})
+        self.assertEqual(rv['root']['z'].getXMLattributes(),
+                         {'a': 'val1', 'b': 'val2'})
+
+    def test_namespace_strip_attributes_negative(self):
+        xml1 = """
+        <root xmlns="http://defaultns.com/"
+              xmlns:a="http://a.com/"
+              xmlns:b="http://b.com/">
+          <x a="val1" a:a="val2">1</x>
+        </root>
+        """
+        xml1 = self.xmlTextToTestFormat(xml1)
+        xml2 = """
+        <root xmlns="http://defaultns.com/"
+              xmlns:a="http://a.com/"
+              xmlns:b="http://b.com/">
+          <x a:a="val1" b:a="val2">1</x>
+        </root>
+        """
+        xml2 = self.xmlTextToTestFormat(xml2)
+        parser = self.Parser(strip_namespace=True)
+        for xml in (xml1, xml2):
+            self.assertRaises(ValueError, parser, xml)
+            self.assertRaises(ValueError, parser, xml, new_style=True)
+
+    def test_newstyle_xmlattribute_get_negative(self):
+        xml = """
+        <root>
+          <x a="val1">1</x>
+        </root>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'root': {
+                'x': '1',
             },
         }
-        self.assertEqual(parse(xml), d)
+        rv = self.parse(xml, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv['root'].hasXMLattributes())
+        self.assertTrue(rv['root']['x'].hasXMLattributes())
+        self.assertEqual(rv['root']['x'].getXMLattribute('a'), "val1")
+        self.assertEqual(rv['root']['x'].getXMLattribute('b', '@@@@'), '@@@@')
+        self.assertRaises(KeyError, rv['root']['x'].getXMLattribute, 'b')
+
+    def test_newstyle_xmlattribute_set(self):
+        xml = """
+        <root>
+          <x a="val1">1</x>
+        </root>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'root': {
+                'x': '1',
+            },
+        }
+        rv = self.parse(xml, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv['root'].hasXMLattributes())
+        self.assertTrue(rv['root']['x'].hasXMLattributes())
+        self.assertEqual(rv['root']['x'].getXMLattribute('a'), "val1")
+        rv['root']['x'].setXMLattribute('a', "val2")
+        self.assertEqual(rv['root']['x'].getXMLattribute('a'), "val2")
+        self.assertRaises(KeyError, rv['root']['x'].getXMLattribute, 'b')
+        rv['root']['x'].setXMLattribute('b', "val3")
+        self.assertEqual(rv['root']['x'].getXMLattribute('a'), "val2")
+        self.assertEqual(rv['root']['x'].getXMLattribute('b'), "val3")
+        self.assertEqual(rv['root']['x'].getXMLattributes(),
+                         {'a': "val2", 'b': "val3"})
+        self.assertEqual(rv['root'].getXMLattributes(), dict())
+        rv['root'].setXMLattribute('newattrib', "@@@")
+        self.assertTrue(rv['root'].hasXMLattributes())
+        self.assertEqual(rv['root'].getXMLattribute('newattrib'), "@@@")
+        self.assertEqual(rv['root'].getXMLattributes(),
+                         {'newattrib': "@@@"})
+
+    def test_newstyle_xmlattribute_delete(self):
+        xml = """
+        <root>
+          <x a="val1">1</x>
+        </root>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'root': {
+                'x': '1',
+            },
+        }
+        rv = self.parse(xml, new_style=True)
+        self.assertEqual(rv, expectedResult)
+        self.assertFalse(rv.hasXMLattributes())
+        self.assertFalse(rv['root'].hasXMLattributes())
+        self.assertTrue(rv['root']['x'].hasXMLattributes())
+        self.assertEqual(rv['root']['x'].getXMLattribute('a'), "val1")
+        self.assertEqual(rv['root']['x'].getXMLattributes(),
+                         {'a': "val1"})
+        self.assertRaises(KeyError, rv['root']['x'].delXMLattribute,
+                          'b')
+        self.assertEqual(rv['root']['x'].getXMLattributes(),
+                         {'a': "val1"})
+        rv['root']['x'].delXMLattribute('a')
+        self.assertFalse(rv['root']['x'].hasXMLattributes())
+        self.assertEqual(rv['root']['x'].getXMLattributes(), dict())
+
+    def test_key_promotion_with_compress(self):
+        xml = """
+        <servers>
+          <server>
+            <name>server1</name>
+            <os>os1</os>
+          </server>
+          <server>
+            <name>server2</name>
+            <os>os2</os>
+          </server>
+        </servers>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'servers': {
+                'server1': {
+                    'name': 'server1',
+                    'os': 'os1',
+                },
+                'server2': {
+                    'name': 'server2',
+                    'os': 'os2',
+                },
+            }
+        }
+        parser = self.Parser(index_keys=('name',))
+        self.assertEqual(parser(xml), expectedResult)
+        self.assertEqual(parser(xml, new_style=True), expectedResult)
+
+    def test_key_promotion_without_compress(self):
+        xml = """
+        <servers>
+          <server>
+            <name>server1</name>
+            <os>os1</os>
+          </server>
+          <server>
+            <name>server2</name>
+            <os>os2</os>
+          </server>
+        </servers>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'servers': {
+                'server':  {
+                    'server1': {
+                        'name': 'server1',
+                        'os': 'os1',
+                    },
+                    'server2': {
+                        'name': 'server2',
+                        'os': 'os2',
+                    },
+                },
+            }
+        }
+        parser = self.Parser(index_keys=('name',), index_keys_compress=False)
+        self.assertEqual(parser(xml), expectedResult)
+        self.assertEqual(parser(xml, new_style=True), expectedResult)
+
+    def test_key_promotion_with_compress_with_force_cdata(self):
+        xml = """
+        <servers>
+          <server>
+            <name>server1</name>
+            <os>os1</os>
+          </server>
+          <server>
+            <name>server2</name>
+            <os>os2</os>
+          </server>
+        </servers>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'servers': {
+                'server1': {
+                    'name': {'#text': 'server1'},
+                    'os': {'#text': 'os1'},
+                },
+                'server2': {
+                    'name': {'#text': 'server2'},
+                    'os': {'#text': 'os2'},
+                },
+            }
+        }
+        parser = self.Parser(index_keys=('name',), force_cdata=True)
+        self.assertEqual(parser(xml), expectedResult)
+        self.assertEqual(parser(xml, new_style=True), expectedResult)
+
+    def test_key_promotion_without_compress_with_force_cdata(self):
+        xml = """
+        <servers>
+          <server>
+            <name>server1</name>
+            <os>os1</os>
+          </server>
+          <server>
+            <name>server2</name>
+            <os>os2</os>
+          </server>
+        </servers>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'servers': {
+                'server':  {
+                    'server1': {
+                        'name': {'#text': 'server1'},
+                        'os': {'#text': 'os1'},
+                    },
+                    'server2': {
+                        'name': {'#text': 'server2'},
+                        'os': {'#text': 'os2'},
+                    },
+                },
+            }
+        }
+        parser = self.Parser(index_keys=('name',), index_keys_compress=False,
+                        force_cdata=True)
+        self.assertEqual(parser(xml), expectedResult)
+        self.assertEqual(parser(xml, new_style=True), expectedResult)
+
+    def test_key_promotion_mixed_with_compress(self):
+        xml = """
+        <servers>
+          <server>
+            <name>server1</name>
+            <os>os1</os>
+          </server>
+          <server>
+            <os>os2</os>
+          </server>
+        </servers>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'servers': {
+                'server1': {
+                    'name': 'server1',
+                    'os': 'os1',
+                },
+                'server': {
+                    'os': 'os2',
+                },
+            }
+        }
+        parser = self.Parser(index_keys=('name',))
+        self.assertEqual(parser(xml), expectedResult)
+        self.assertEqual(parser(xml, new_style=True), expectedResult)
+
+    def test_key_promotion_mixed_without_compress(self):
+        test_xmls = ["""
+        <servers>
+          <server>
+            <name>server1</name>
+            <os>os1</os>
+          </server>
+          <server>
+            <os>os2</os>
+          </server>
+        </servers>
+        """,
+        """
+        <servers>
+          <server>
+            <os>os1</os>
+          </server>
+          <server>
+            <name>server2</name>
+            <os>os2</os>
+          </server>
+        </servers>
+        """,
+        """
+        <servers>
+          <server>
+            <os>os1</os>
+          </server>
+          <server>
+            <name>server2</name>
+            <os>os2</os>
+          </server>
+          <server>
+            <os>os3</os>
+          </server>
+        </servers>
+        """,
+        """
+        <servers>
+          <server>
+            <name>server1</name>
+            <os>os1</os>
+          </server>
+          <server>
+            <os>os2</os>
+          </server>
+          <server>
+            <name>server3</name>
+            <os>os3</os>
+          </server>
+        </servers>
+        """,
+        ]
+        parser = self.Parser(index_keys=('name',), index_keys_compress=False)
+        for xml in test_xmls:
+            xml = self.xmlTextToTestFormat(xml)
+            self.assertRaises(ValueError, parser, xml)
+            self.assertRaises(ValueError, parser, xml, new_style=True)
+
+    def test_key_promotion_list_with_compress(self):
+        xml = """
+        <servers>
+          <server>
+            <name>server1</name>
+            <os>os1</os>
+          </server>
+          <server>
+            <name>server1</name>
+            <os>os2</os>
+          </server>
+          <server>
+            <name>server2</name>
+            <os>os2</os>
+          </server>
+        </servers>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'servers': {
+                'server1': [
+                    {
+                        'name': 'server1',
+                        'os': 'os1',
+                    },
+                    {
+                        'name': 'server1',
+                        'os': 'os2',
+                    },
+                ],
+                'server2': {
+                    'name': 'server2',
+                    'os': 'os2',
+                },
+            }
+        }
+        parser = self.Parser(index_keys=('name',))
+        self.assertEqual(parser(xml), expectedResult)
+        self.assertEqual(parser(xml, new_style=True), expectedResult)
+
+    def test_key_promotion_list_without_compress(self):
+        xml = """
+        <servers>
+          <server>
+            <name>server1</name>
+            <os>os1</os>
+          </server>
+          <server>
+            <name>server1</name>
+            <os>os2</os>
+          </server>
+          <server>
+            <name>server2</name>
+            <os>os2</os>
+          </server>
+        </servers>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'servers': {
+                'server': {
+                    'server1': [
+                        {
+                            'name': 'server1',
+                            'os': 'os1',
+                        },
+                        {
+                            'name': 'server1',
+                            'os': 'os2',
+                        },
+                    ],
+                    'server2': {
+                        'name': 'server2',
+                        'os': 'os2',
+                    },
+                },
+            }
+        }
+        parser = self.Parser(index_keys=('name',), index_keys_compress=False)
+        self.assertEqual(parser(xml), expectedResult)
+        self.assertEqual(parser(xml, new_style=True), expectedResult)
+
+    def test_force_list_basic(self):
+        xml = """
+        <servers>
+          <server>
+            <name>server1</name>
+            <os>os1</os>
+          </server>
+        </servers>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'servers': {
+                'server': [
+                    {
+                        'name': 'server1',
+                        'os': 'os1',
+                    },
+                ],
+            }
+        }
+        parser = self.Parser(force_list=('server',))
+        self.assertEqual(parser(xml), expectedResult)
+        self.assertEqual(parser(xml, new_style=True), expectedResult)
+
+    def test_force_list_with_index_key_compress(self):
+        xml = """
+        <servers>
+          <server>
+            <name>server1</name>
+            <os>os1</os>
+          </server>
+        </servers>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'servers': {
+                'server1': {
+                    'name': 'server1',
+                    'os': 'os1',
+                },
+            }
+        }
+        parser = self.Parser(force_list=('server',), index_keys=('name',))
+        self.assertEqual(parser(xml), expectedResult)
+        self.assertEqual(parser(xml, new_style=True), expectedResult)
+
+    def test_force_list_without_index_key_compress(self):
+        xml = """
+        <servers>
+          <server>
+            <name>server1</name>
+            <os>os1</os>
+          </server>
+        </servers>
+        """
+        xml = self.xmlTextToTestFormat(xml)
+        expectedResult = {
+            'servers': {
+                'server': {
+                    'server1': {
+                        'name': 'server1',
+                        'os': 'os1',
+                    },
+                },
+            }
+        }
+        parser = self.Parser(force_list=('server',), index_keys=('name',),
+                        index_keys_compress=False)
+        self.assertEqual(parser(xml), expectedResult)
+        self.assertEqual(parser(xml, new_style=True), expectedResult)
+
+class EtreeToDictTestCase(XMLToDictTestCase):
+    def __init__(self, *args, **kwargs):
+        XMLToDictTestCase.__init__(self, *args, **kwargs)
+        self.parse=parse_lxml
+        self.Parser=LXMLParser
+
+    def xmlTextToTestFormat(self, xml):
+        try:
+            return xmltodict.etree.fromstring(xml)
+        except UnicodeEncodeError:
+            xml = xml.encode('utf-8')
+            return xmltodict.etree.fromstring(xml)
+
+    @unittest.skip("Test does not make sense in the Etree context")
+    def test_string_vs_file(self):
+        pass
+
+    def test_element_vs_element_tree(self):
+        xml = '<a>data</a>'
+        xml_element = xmltodict.etree.fromstring(xml)
+        xml_elementtree = xmltodict.etree.ElementTree(xml_element)
+        self.assertEqual(self.parse(xml_element),
+                         self.parse(xml_elementtree))
+
+class NewStyleClassTestCase(unittest.TestCase):
+    def pprint_compare(self, obj1, obj2, **kwargs):
+        ioObj1 = StringIO()
+        obj1.prettyprint(width=1000, stream=ioObj1, **kwargs)
+        ioObj2 = StringIO()
+        xmltodict.pprint(obj2, width=1000, stream=ioObj2, **kwargs)
+        self.assertEqual(ioObj1.getvalue(), ioObj2.getvalue())
+
+    def test_newstyle_prettyprint(self):
+        data1_orig = u"data1"
+        data1 = xmltodict.XMLCDATANode(data1_orig)
+        data2_orig = u"data2"
+        data2 = xmltodict.XMLCDATANode(data2_orig)
+        list1_orig = [data1_orig, data2_orig]
+        list1 = xmltodict.XMLListNode((data1, data2))
+        nodec = xmltodict.XMLDictNode({u'c': list1})
+        nodeb = xmltodict.XMLDictNode({u'b': nodec})
+        nodea = xmltodict.XMLDictNode({u'a': nodeb})
+
+        for depth in (None, 1, 2, 3, 4, 5):
+            #dict level
+            self.pprint_compare(nodea,
+                                {u'a': {u'b': {u'c': list1_orig}}},
+                                depth=depth)
+
+            # list level
+            self.pprint_compare(list1, list1_orig, depth=depth)
+
+            # CDATA level
+            self.pprint_compare(data1, data1_orig, depth=depth)
+
+        # Check non-XML*Node elements under an XML*Node element
+        list1 = xmltodict.XMLListNode((data1, data2_orig))
+        self.pprint_compare(list1, list1_orig)
+        nodec[u'd'] = data2_orig
+        self.pprint_compare(nodec,
+                            {u'c': list1_orig, u'd': data2_orig})

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -1193,9 +1193,9 @@ class NewStyleClassTestCase(unittest.TestCase):
         self.assertEqual(ioObj1.getvalue(), ioObj2.getvalue())
 
     def test_newstyle_prettyprint(self):
-        data1_orig = "data1"
+        data1_orig = unicode("data1")
         data1 = xmltodict.XMLCDATANode(data1_orig)
-        data2_orig = "data2"
+        data2_orig = unicode("data2")
         data2 = xmltodict.XMLCDATANode(data2_orig)
         list1_orig = [data1_orig, data2_orig]
         list1 = xmltodict.XMLListNode((data1, data2))

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -61,7 +61,7 @@ def getXMLattribute(self, attr, defval=NoArg()):
 _XMLNodeMetaClassImports.append(getXMLattribute)
 
 def _XMLNodeMetaClassRepr(self):
-    return "%s(XMLattrs=%r, value=%s)" % (self.__class__.__name__, self.XMLattrs, self.__parent__.__repr__(self))
+    return "%s(XMLattrs=%r, value=%s)" % (getattr(self, "__const_class_name__", self.__class__.__name__), self.XMLattrs, self.__parent__.__repr__(self))
 
 class XMLNodeMetaClass(type):
     def __new__(cls, name, bases, dict):
@@ -72,11 +72,9 @@ class XMLNodeMetaClass(type):
             dict[method.__name__] = method
         return type.__new__(cls, name, bases, dict)
     def __call__(self, *args, **kwargs):
-        print "args = %r, kwargs = %r" % (args, kwargs)
         XMLattrs=kwargs.pop("XMLattrs", dict())
         obj = type.__call__(self, *args, **kwargs)
         obj.XMLattrs = XMLattrs
-        #obj.hasXMLattributes = self.hasXMLattributes
         return obj
 
 class XMLCDATANode(_unicode):
@@ -94,7 +92,9 @@ class OrderedDict(_OrderedDict):
             # the main object's class. This logic temporarily
             # resets the class name so this appears to be
             # what it (fundamentally) is: an OrderedDict
-            # object.
+            # object. (For this reason, there is also extra
+            # logic to make the XMLDictNode __repr__ function
+            # work correctly.)
             self.__class__.__name__ = _OrderedDict.__name__
             rv = _OrderedDict.__repr__(self, _repr_running)
         except:
@@ -105,6 +105,9 @@ class OrderedDict(_OrderedDict):
 
 class XMLDictNode(OrderedDict):
     __metaclass__ = XMLNodeMetaClass
+    def __init__(self, *args, **kwargs):
+        self.__const_class_name__ = self.__class__.__name__
+        OrderedDict.__init__(self, *args, **kwargs)
 
 class ParsingInterrupted(Exception):
     pass

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -407,6 +407,47 @@ class _DictSAXHandler(object):
                 setattr(item[key], self.delete_key, True)
         return item
 
+class Parser(object):
+    def __init__(self, encoding=None, expat=expat,
+                 process_namespaces=False, namespace_separator=':',
+                 **kwargs):
+        self.encoding=encoding
+        self.expat=expat
+        self.process_namespaces=process_namespaces
+        self.namespace_separator=namespace_separator
+        self.kwargs=kwargs
+
+        # Try the arguments to catch argument errors now. We will toss
+        # out the created handler and parser, anyway.
+        handler = _DictSAXHandler(namespace_separator=namespace_separator,
+                                  **kwargs)
+        if not encoding:
+            encoding = 'utf-8'
+        if not process_namespaces:
+            namespace_separator = None
+        parser = expat.ParserCreate(
+            encoding,
+            namespace_separator
+        )
+        del handler
+        del parser
+    def __call__(self, xml_input, **kwargs):
+        # NOTE: For now, this just calls the external parse()
+        # method. I would prefer to rewrite this so the external
+        # parse() method just calls this class (similar to the
+        # relationship between the parse_lxml() method and the
+        # LXMLParser class). However, I am writing this class in this
+        # way to make the diffs easier to read.
+        encoding = kwargs.pop('encoding', self.encoding)
+        expat = kwargs.pop('expat', self.expat)
+        process_namespaces = kwargs.pop('process_namespaces',
+                                        self.process_namespaces)
+        namespace_separator = kwargs.pop('namespace_separator',
+                                         self.namespace_separator)
+        newkwargs = dict(self.kwargs)
+        newkwargs.update(kwargs)
+        return parse(xml_input, encoding, expat, process_namespaces,
+                     namespace_separator, **newkwargs)
 
 def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
           namespace_separator=':', **kwargs):

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -373,7 +373,7 @@ class _DictSAXHandler(object):
                 return item
             key, data = result
         result = self._promote_keys(key, data)
-        if self.index_keys_compress and not result is None:
+        if self.index_keys_compress and result is not None:
             key, data = result
         if item is None:
             item = self.dict_constructor()
@@ -382,7 +382,7 @@ class _DictSAXHandler(object):
                 value = item[key]
                 if isinstance(value, list):
                     value.append(data)
-                if isinstance(value, dict) and (not self.index_keys_compress) and getattr(value, self.delete_key, False):
+                elif isinstance(value, dict) and (not self.index_keys_compress) and getattr(value, self.delete_key, False):
                     raise ValueError("Mixture of data types: some have index keys and some do not, while processing \"%s\" key" % key)
                 else:
                     item[key] = self.list_constructor((value, data))
@@ -627,7 +627,7 @@ if etree:
             namespace_dict = {'nexttag': _unicode('ns0')}
         if node.tag not in (etree.PI, etree.Comment):
             # Make attribute copy
-            attrib = node.attrib.copy()
+            attrib = dict(node.attrib)
 
             # Figure out NS:
             # If 'strip_namespace' is set, just strip it out here to save
@@ -721,8 +721,16 @@ if etree:
                                  len(args) + len(kwargs)))
             handler = _DictSAXHandler(namespace_separator=self.namespace_separator,
                                       **self.kwargs)
-            if isinstance(lxml_root, etree.ElementTree):
-                lxml_root = lxml_root.getroot()
+            try:
+                if isinstance(lxml_root, etree._ElementTree):
+                    lxml_root = lxml_root.getroot()
+            except:
+                try:
+                    if isinstance(lxml_root, etree.ElementTree):
+                        lxml_root = lxml_root.getroot()
+                except:
+                    if not hasattr(lxml_root, 'tag'):
+                        lxml_root = lxml_root.getroot()
             parse_lxml_node(lxml_root, handler,
                             self.process_namespaces,
                             self.strip_namespace,

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -120,13 +120,13 @@ class OrderedDict(_OrderedDict):
 
 class _XMLNodeMetaClass(type):
     def __new__(cls, name, bases, dict):
-        dict["XMLattrs"] = OrderedDict()
+        dict["xml_attrs"] = OrderedDict()
         dict["__parent__"] = bases[-1]
         return type.__new__(cls, name, bases, dict)
     def __call__(self, *args, **kwargs):
-        XMLattrs=kwargs.pop("XMLattrs", OrderedDict())
+        xml_attrs=kwargs.pop("xml_attrs", OrderedDict())
         obj = type.__call__(self, *args, **kwargs)
-        obj.XMLattrs = XMLattrs
+        obj.xml_attrs = xml_attrs
         return obj
 
 
@@ -146,36 +146,36 @@ XMLNodeMetaClass = _XMLNodeMetaClass(str("XMLNodeMetaClass"),
 del _temp_class_dict
 
 class XMLNodeBase(XMLNodeMetaClass):
-    def hasXMLattributes(self):
-        if len(self.XMLattrs) > 0:
+    def has_xml_attrs(self):
+        if len(self.xml_attrs) > 0:
             return True
         return False
 
-    def setXMLattribute(self, attr, val):
-        self.XMLattrs[attr] = val
+    def set_xml_attr(self, attr, val):
+        self.xml_attrs[attr] = val
 
-    def getXMLattribute(self, attr, defval=NoArg()):
+    def get_xml_attr(self, attr, defval=NoArg()):
         try:
-            return self.XMLattrs[attr]
+            return self.xml_attrs[attr]
         except KeyError:
             if not isinstance(defval, NoArg):
                 return defval
             raise
 
-    def getXMLattributes(self):
-        return self.XMLattrs
+    def get_xml_attrs(self):
+        return self.xml_attrs
 
-    def delXMLattribute(self, attr):
-        del self.XMLattrs[attr]
+    def delete_xml_attr(self, attr):
+        del self.xml_attrs[attr]
 
     def __repr__(self):
-        return "%s(XMLattrs=%r, value=%s)" % (getattr(self, "__const_class_name__", self.__class__.__name__), self.XMLattrs, self.__parent__.__repr__(self))
+        return "%s(xml_attrs=%r, value=%s)" % (getattr(self, "__const_class_name__", self.__class__.__name__), self.xml_attrs, self.__parent__.__repr__(self))
 
 
 class XMLCDATANode(XMLNodeBase, _unicode):
     def strip(self, arg=None):
         newtext = _unicode.strip(self, arg)
-        return XMLCDATANode(newtext, XMLattrs=self.XMLattrs)
+        return XMLCDATANode(newtext, xml_attrs=self.xml_attrs)
     def prettyprint(self, *args, **kwargs):
         currdepth = kwargs.pop("currdepth", 0)
         newobj = self.__parent__(self)
@@ -376,7 +376,7 @@ class _DictSAXHandler(object):
                     node = None
                 if node is not None:
                     for (key, value) in attrs.items():
-                        node.setXMLattribute(key, value)
+                        node.set_xml_attr(key, value)
             if item is not None:
                 if data:
                     self.push_data(item, self.cdata_key, data)
@@ -723,14 +723,14 @@ def parse(xml_input, encoding=None, expat=expat,
     in a class attribute, rather than being placed in a dictionary
     entry. The XML attributes are accessible/settable using these
     functions:
-        obj.hasXMLattributes(): Returns True if there are XML
+        obj.has_xml_attrs(): Returns True if there are XML
           attributes, or False otherwise.
-        obj.setXMLattribute(attr, val): Sets the XML attribute of name
+        obj.set_xml_attr(attr, val): Sets the XML attribute of name
          `attr` to `val`.
-        obj.getXMLattribute(attr[, default]): Gets the XML attribute
+        obj.get_xml_attr(attr[, default]): Gets the XML attribute
           of name `attr`. If there is no such attribute, it will
           return default (if supplied) or raise a KeyError.
-        obj.delXMLattribute(attr, val): Deletes the XML attribute of name
+        obj.delete_xml_attr(attr, val): Deletes the XML attribute of name
          `attr`.
 
     The classes returned when the `new_style` argument is True also
@@ -1066,7 +1066,7 @@ def _emit(key, value, content_handler,
     for index, v in enumerate(value):
         if full_document and depth == 0 and index > 0:
             raise ValueError('document with multiple roots')
-        attrs = getattr(v, "XMLattrs", OrderedDict())
+        attrs = getattr(v, "xml_attrs", OrderedDict())
         if v is None:
             v = OrderedDict()
         elif not isinstance(v, dict):

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -714,13 +714,19 @@ if etree:
             self.allow_extra_args = allow_extra_args
             self.kwargs = kwargs
             self.strip_namespace = kwargs.get('strip_namespace',False)
-        def __call__(self, lxml_root, *args, **kwargs):
-            if (len(args) + len(kwargs)) > 0 and not self.allow_extra_args:
-                raise TypeError("%s callable takes 1 argument (%d given)" %
-                                (self.__class__.__name__,
-                                 len(args) + len(kwargs)))
             handler = _DictSAXHandler(namespace_separator=self.namespace_separator,
-                                      **self.kwargs)
+                                      **kwargs)
+            del handler
+        def __call__(self, lxml_root, *args, **kwargs):
+            if len(args) > 0 and not self.allow_extra_args:
+                raise TypeError("%s callable takes 1 argument (%d given)" %
+                                (self.__class__.__name__, len(args)))
+
+            newkwargs = dict(self.kwargs)
+            newkwargs.update(kwargs)
+
+            handler = _DictSAXHandler(namespace_separator=self.namespace_separator,
+                                      **newkwargs)
             try:
                 if isinstance(lxml_root, etree._ElementTree):
                     lxml_root = lxml_root.getroot()

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -65,6 +65,11 @@ def getXMLattribute(self, attr, defval=NoArg()):
 
 _XMLNodeMetaClassImports.append(getXMLattribute)
 
+def delXMLattribute(self, attr):
+    del self.XMLattrs[attr]
+
+_XMLNodeMetaClassImports.append(delXMLattribute)
+
 def _XMLNodeMetaClassRepr(self):
     return "%s(XMLattrs=%r, value=%s)" % (getattr(self, "__const_class_name__", self.__class__.__name__), self.XMLattrs, self.__parent__.__repr__(self))
 
@@ -528,6 +533,8 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
         obj.getXMLattribute(attr[, default]): Gets the XML attribute
           of name `attr`. If there is no such attribute, it will
           return default (if supplied) or raise a KeyError.
+        obj.delXMLattribute(attr, val): Deletes the XML attribute of name
+         `attr`.
 
     The classes returned when the `new_style` argument is True also
     have a `prettyprint` method, which is mostly a pass-through to the

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -120,7 +120,7 @@ class _XMLNodeMetaClass(type):
 # The below is Python 2/3 Portable equivalent to
 #   class XMLNodeMetaClass(object, metaclass=_XMLNodeMetaClass):
 #       pass
-if sys.version_info.major >= 3:
+if sys.version_info[0] >= 3:
     _temp_class_dict = {'__module__': _XMLNodeMetaClass.__module__,
                         '__qualname__': 'XMLNodeMetaClass'}
 else:


### PR DESCRIPTION
I implemented several enhancements:
* The ability to create dictionaries of elements based on known index-key elements.
* The ability to force lists for certain tags.
* The ability to strip namespaces from results.
* The ability to receive data in new data structures that separate the XML attributes from the data.
* The ability to parse ElementTree data into a dictionary.
* The ability to use new parsing classes that keep track of default options.
* The ability to use an iterator in streaming mode.
* Whitespace stripping now applies to data in streaming mode.

While implementing the enhancements, I took care not to disturb the default behavior. Therefore, all the changes should not impact existing users.

Also, all the changes have unit tests that cover them. (The code coverage is > 90%. Most of the misses are in lines of code that are meant to handle variations on the Element/ElementTree objects, depending on which library created them.)

# Index Keys
Imagine you have this input:
```xml
<servers>
    <server>
        <name>server1</name>
        <os>Linux</os>
    </server>
    <server>
        <name>server2</name>
        <os>Windows</os>
    </server>
</servers>
```
In this case, it might be helpful to have the 'servers' dictionary keyed off of the server name. You can now do this using the index_keys option. With this option, the named tags will be "promoted" to be the key for their subtree.

So, for example, the index_keys=('name',) option will produce this data structure:
```python
{u'servers': {u'server1': {u'name': u'server1',
                           u'os': u'Linux'},
              u'server2': {u'name': u'server2',
                           u'os': u'Windows'}}}
```
But, what if you need the "server" tag because it is intermixed with other tags? In that case, you can turn off the "index_keys_compress" option.

For example:
```python
>>> xmltodict.parse("""
... <devices>
...     <server>
...         <name>server1</name>
...         <os>Linux</os>
...     </server>
...     <server>
...         <name>server2</name>
...         <os>Windows</os>
...     </server>
...     <workstation>
...         <name>host1</name>
...         <os>Linux</os>
...     </workstation>
...     <workstation>
...         <name>host2</name>
...         <os>Windows</os>
...     </workstation>
... </devices>
... """, new_style=True, index_keys=('name',), index_keys_compress=False).prettyprint(width=2)
{u'devices': {u'server': {u'server1': {u'name': u'server1',
                                       u'os': u'Linux'},
                          u'server2': {u'name': u'server2',
                                       u'os': u'Windows'}},
              u'workstation': {u'host1': {u'name': u'host1',
                                          u'os': u'Linux'},
                               u'host2': {u'name': u'host2',
                                          u'os': u'Windows'}}}}
```
# Force Lists
Sometimes, you have a node that may have one or more items. Rather than testing for both a list and single item, you can simplify your code by having the xmltodict parser always create a list for you.

For example, compare these outputs:
```python
>>> xmltodict.parse("""
... <servers>
...     <server>
...         <name>server1</name>
...         <os>Linux</os>
...     </server>
... </servers>
... """, new_style=True).prettyprint(width=2) 
{u'servers': {u'server': {u'name': u'server1',
                          u'os': u'Linux'}}}
>>> xmltodict.parse("""
... <servers>
...     <server>
...         <name>server1</name>
...         <os>Linux</os>
...     </server>
...     <server>
...         <name>server2</name>
...         <os>Windows</os>
...     </server>
... </servers>
... """, new_style=True).prettyprint(width=2) 
{u'servers': {u'server': [{u'name': u'server1',
                           u'os': u'Linux'},
                          {u'name': u'server2',
                           u'os': u'Windows'}]}}
```
In the first case rv['servers']['server'] points to a single item. In the second case, rv['servers']['server'] points to a list.

You can force this to always be a list by setting the "force_list" parameter:
```python
>>> xmltodict.parse("""
... <servers>
...     <server>
...         <name>server1</name>
...         <os>Linux</os>
...     </server>
... </servers>
... """, new_style=True, force_list=('server',)).prettyprint(width=2)
{u'servers': {u'server': [{u'name': u'server1',
                           u'os': u'Linux'}]}}
```

# Strip Namespaces
Let me start by granting the truth that XML namespaces are an essential part of node and attribute names. Now, having said that, there are times when the namespaces are already well-known and are merely extra information that a user can (and will try to) safely ignore. In these cases, you can set the "strip_namespace" option to strip namespaces.

For example:
```python
>>> xmltodict.parse("""
... <servers xmlns="http://a.com/" xmlns:b="http://b.com/">
...     <b:server>
...         <name>test</name>
...     </b:server>
... </servers>
... """, new_style=True, strip_namespace=True).prettyprint(width=2)
{u'servers': {u'server': {u'name': u'test'}}}
```

# New Classes
One of the difficulties in dealing with XML data in Python is representing the richness of the XML data (including, especially, the dual layers of attributes and data) while creating the simplest data structure possible. I'm sure many people have tried. I tried again.

The fundamental premise here is this: if a user cares about an XML attribute, he/she knows to go looking for it. So, it is most important to present the main data in a simple format, and it is sufficient to provide one or more methods for users to find XML attributes.

The three data structures are:
* XMLCDATANode: This "quacks" like a string/unicode. (For example, XMLCDATANode("a") == "a" will evaluate to true.)
* XMLDictNode: This "quacks" like a dict or OrderedDict.
* XMLListNode: This "quacks" like a list.

These data structures have some extra methods to deal with attributes:
* has_xml_attrs(): Returns True if there are XML attributes; False otherwise.
* get_xml_attr(name[, default]): Returns the value of the XML attribute if it exists. Otherwise, it will return the default, if given, or raise a KeyError.
* set_xml_attr(name, value): Sets the value of the XML attribute.
* delete_xml_attr(name): Delete the XML attribute. Raises a KeyError if the XML attribute does not exists.
* get_xml_attr(): Returns the dictionary of XML attributes.

These data structures also implement a prettyprint() method which takes the same options as pprint() (except, of course, for the object to be printed). The prettyprint() method prints out the __data__ only and does not show the XML attributes. This decision was made for readability purposes. The __repr__() method shows both.

I've already shown some examples of the new classes above. Here's another example:
```python
>>> rv = xmltodict.parse("""
... <servers>
...     <server coolness="high">
...         <name>server1</name>
...     </server>
... </servers>
... """, new_style=True)
>>> repr(rv)
"XMLDictNode(xml_attrs=OrderedDict(), value=OrderedDict([(u'servers', XMLDictNode(xml_attrs=OrderedDict(), value=OrderedDict([(u'server', XMLDictNode(xml_attrs=OrderedDict([(u'coolness', u'high')]), value=OrderedDict([(u'name', XMLCDATANode(xml_attrs=OrderedDict(), value=u'server1'))])))])))]))"
>>> rv.prettyprint(width=2)
{u'servers': {u'server': {u'name': u'server1'}}}
>>> rv.has_xml_attrs()
False
>>> rv['servers'].has_xml_attrs()
False
>>> rv['servers']['server'].has_xml_attrs()
True
>>> rv['servers']['server'].get_xml_attrs()
OrderedDict([(u'coolness', u'high')])
>>> rv['servers']['server'].get_xml_attr('coolness')
u'high'
>>> rv['servers']['server'].get_xml_attr('darkness', '@@NOTFOUND@@')
'@@NOTFOUND@@'
>>> rv['servers']['server']['name']
XMLCDATANode(XMLattrs=OrderedDict(), value=u'server1')
>>> rv['servers']['server']['name'] == 'server1'
True
>>> rv['servers']['server'].set_xml_attr('coolness', 'low')
>>> rv['servers'].set_xml_attr('length', '1')
>>> rv['servers'].set_xml_attr('delete_me', True)
>>> rv['servers'].delete_xml_attr('delete_me')
>>> xmltodict.unparse(rv)
u'<?xml version="1.0" encoding="utf-8"?>\n<servers length="1"><server coolness="low"><name>server1</name></server></servers>'
```

# Parsing ElementTree Data
Sometimes, a user may use a library that returns an Element or ElementTree. In those cases, it would be useful to be able to convert it into an easy to use dictionary without having to first convert it to text. In those cases, the user can use the parse_lxml() method. (This was originally intended for lxml; hence, the name. However, it should work with ElementTree, as well. Indeed, I did much of my testing with cElementTree.)

The parse_lxml() method should take the same options as the parse() method.

Example:
```python
>>> xml = etree.XML("<a><b>data</b></a>")
>>> xmltodict.parse_lxml(xml, new_style=True).prettyprint()
{'a': {'b': u'data'}}
```

# Parsing Classes
Two new classes hold parsing defaults. They can be overridden on each invocation.

* The Parser() class is used for parsing XML text.
* The LXMLParser() class is used for parsing ElementTree objects.

Example:
```python
>>> parser = xmltodict.Parser(new_style=True, index_keys=('name',))
>>> parser("<a><b><name>item1</name></b></a>").prettyprint()
{u'a': {u'item1': {u'name': u'item1'}}}
>>> parser("<a><b><name>item1</name></b></a>", index_keys=()).prettyprint()
{u'a': {u'b': {u'name': u'item1'}}}
>>> parser("<a><b><name>item1</name></b></a>", index_keys_compress=False).prettyprint()
{u'a': {u'b': {u'item1': {u'name': u'item1'}}}}
```
# Iterators/Generators
In streaming mode, you can now use an iterator/generator to loop through the list of matching items. This will be done with incremental parsing of the input file (however, see note below about Jython). The input file is processed 1KB at a time and then each matching node is returned on a subsequent iteration. Once all the matching nodes from the first 1KB are returned, the next 1KB is read (and so on).

(Note: I'm not sure why, but the Travis CI test shows that Jython is failing the unit test that checks to make sure that the parsing really is done incrementally. I need to do more examination to determine whether this is a true failure, or a false failure due to a flaw in the test.)

If the `generator` argument evaluates to True and `item_depth` is non-zero, the parser will return an iterator. On each iteration, the code will return the next (path, item) tuple at the `item_depth` level. These are the same items (in the same format) that would be passed to the callback function; however, they are returned at each iteration.

Two corner cases: If `generator` is True and `item_depth` is zero, the code will return a single-item list with an empty path and the full document. If `generator` is True and `item_callback` is also set, the `item_callback` will be executed for each iteration prior to the iterator's return.

Example:
```python
>>> xml = """\
... <a prop="x">
...   <b>1</b>
...   <b>2</b>
... </a>"""
>>> for (path, item) in xmltodict.parse(xml, generator=True, item_depth=2):
...     print 'path:%s item:%s' % (path, item)
...
path:[(u'a', {u'prop': u'x'}), (u'b', None)] item:1
path:[(u'a', {u'prop': u'x'}), (u'b', None)] item:2
```

# Whitespace Stripping Enhancement
In streaming mode, whitespace stripping now applies to streaming mode. Previously, if the item at the `item_depth` was a CDATA node, whitespace stripping was not applied prior to the item being sent to the callback function. Now, whitespace stripping takes effect prior to the call to the callback function (or return of a value from the iterator).

(Whitespace stripping is still controlled by the `strip_whitespace` argument.)

Example of the previous behavior:
```python
>>> print xml2
<a>
  <b>
    <c>data1</c>
    <d>data2</d>
    <c>data3</c>
  </b>
  <b>
    <c>data4</c>
    <d>data5</d>
    <c>data6</c>
  </b>
</a>

>>> for (stack, value) in xmltodict.parse(xml2, generator=True, item_depth=3, item_callback=cb):
...     print "\tValue: %r" % value
... 
	Value: u'\n  \n    data1'
	Value: u'\n    data2'
	Value: u'\n    data3'
	Value: u'\n  \n    data4'
	Value: u'\n    data5'
	Value: u'\n    data6'
```
Example of the new behavior:
```python
>>> for (stack, value) in xmltodict.parse(xml2, generator=True, item_depth=3):
...     print "\tValue: %r" % value
... 
	Value: u'data1'
	Value: u'data2'
	Value: u'data3'
	Value: u'data4'
	Value: u'data5'
	Value: u'data6'
```