### PR TITLE
Add description of cdata_key and attr_prefix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,23 @@ You can also convert in the other direction, using the `unparse()` method:
 </response>
 ```
 
+Text values for nodes can be specified with the `cdata_key` key in the python dict, while node properties can be specified with the `attr_prefix` prefixed to the key name in the python dict. The default value for `attr_prefix` is `@` and the default value for `cdata_key` is `#text`.
+
+```python
+>>> import xmltodict
+>>> 
+>>> mydict = {
+...     'text': {
+...         '@color':'red',
+...         '@stroke':'2',
+...         '#text':'This is a test'
+...     }
+... }
+>>> print xmltodict.unparse(mydict, pretty=True)
+<?xml version="1.0" encoding="utf-8"?>
+<text stroke="2" color="red">This is a test</text>
+```
+
 ## Ok, how do I get it?
 
 You just need to


### PR DESCRIPTION
Add description of using the cdata_key and attr_prefix to specify node properties and values. 

I found this part really confusing until I read the comments that were directly in the code; it would be nice if there were a description in the README.