### PR TITLE
Fixed defusedexpat expat import

### DIFF
--- a/xmltodict.py
+++ b/xmltodict.py
@@ -2,7 +2,7 @@
 "Makes working with XML feel like you are working with JSON"
 
 try:
-    import defusedexpat as expat
+    from defusedexpat import pyexpat as expat
 except ImportError:
     from xml.parsers import expat
 from xml.sax.saxutils import XMLGenerator


### PR DESCRIPTION
Original defused expat import was broken and not pointing to the location of defusedexpat's expat (pyexpat), raising the following error on parse:

"AttributeError: 'module' object has no attribute 'ParserCreate'"