### PR TITLE
unparse: pass short_empty_elements to XMLGenerator

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -163,3 +163,9 @@ class DictToXMLTestCase(unittest.TestCase):
     def test_non_string_attr(self):
         obj = {'a': {'@attr': 1}}
         self.assertEqual('<a attr="1"></a>', _strip(unparse(obj)))
+
+    def test_short_empty_elements(self):
+        if sys.version_info < (3, 2):
+            return
+        obj = {'a': None}
+        self.assertEqual('<a/>', _strip(unparse(obj, short_empty_elements=True)))

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -371,6 +371,7 @@ def _emit(key, value, content_handler,
 
 
 def unparse(input_dict, output=None, encoding='utf-8', full_document=True,
+            short_empty_elements=False,
             **kwargs):
     """Emit an XML document for the given `input_dict` (reverse of `parse`).
 
@@ -392,7 +393,10 @@ def unparse(input_dict, output=None, encoding='utf-8', full_document=True,
     if output is None:
         output = StringIO()
         must_return = True
-    content_handler = XMLGenerator(output, encoding)
+    if short_empty_elements:
+        content_handler = XMLGenerator(output, encoding, True)
+    else:
+        content_handler = XMLGenerator(output, encoding)
     if full_document:
         content_handler.startDocument()
     for key, value in input_dict.items():


### PR DESCRIPTION
short_empty_elements is introduced in Python 3.2.
set short_empty_elements to True, if we want single self-closed tags.