### PR TITLE
Disable entities

### DIFF
--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -345,7 +345,13 @@ class XMLToDictTestCase(unittest.TestCase):
             parser.ExternalEntityRefHandler = lambda *x: 0
             return parser
         expat.ParserCreate = raising_external_ref_handler
-        with self.assertRaises(expat.ExpatError):
-            self.assertRaises(TypeError, parse(xml, disable_entities=False, expat=expat))
+        # Using this try/catch because a TypeError is thrown before 
+        # the ExpatError, and Python 2.6 is confused by that.
+        try:
+            parse(xml, disable_entities=False, expat=expat)
+        except expat.ExpatError:
+            self.assertTrue(True)
+        else:
+            self.assertTrue(False)
         expat.ParserCreate = ParserCreate
 

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -9,6 +9,8 @@ try:
 except ImportError:
     from xmltodict import StringIO
 
+from xml.parsers.expat import ParserCreate
+from xml.parsers import expat
 
 def _encode(s):
     try:
@@ -295,3 +297,55 @@ class XMLToDictTestCase(unittest.TestCase):
             },
         }
         self.assertEqual(parse(xml, force_list=force_list, dict_constructor=dict), expectedResult)
+
+    def test_disable_entities_true_ignores_xmlbomb(self):
+        xml = """
+        <!DOCTYPE xmlbomb [
+            <!ENTITY a "1234567890" >
+            <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;">
+            <!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;">
+        ]>
+        <bomb>&c;</bomb>
+        """
+        expectedResult = {'bomb': None}
+        self.assertEqual(parse(xml, disable_entities=True), expectedResult)
+
+    def test_disable_entities_false_returns_xmlbomb(self):
+        xml = """
+        <!DOCTYPE xmlbomb [
+            <!ENTITY a "1234567890" >
+            <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;">
+            <!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;">
+        ]>
+        <bomb>&c;</bomb>
+        """
+        bomb = "1234567890" * 64
+        expectedResult = {'bomb': bomb}
+        self.assertEqual(parse(xml, disable_entities=False), expectedResult)
+
+    def test_disable_entities_true_ignores_external_dtd(self):
+        xml = """
+        <!DOCTYPE external [
+            <!ENTITY ee SYSTEM "http://www.python.org/">
+        ]>
+        <root>&ee;</root>
+        """
+        expectedResult = {'root': None}
+        self.assertEqual(parse(xml, disable_entities=True), expectedResult)
+
+    def test_disable_entities_true_attempts_external_dtd(self):
+        xml = """
+        <!DOCTYPE external [
+            <!ENTITY ee SYSTEM "http://www.python.org/">
+        ]>
+        <root>&ee;</root>
+        """
+        def raising_external_ref_handler(*args, **kwargs):
+            parser = ParserCreate(*args, **kwargs)
+            parser.ExternalEntityRefHandler = lambda *x: 0
+            return parser
+        expat.ParserCreate = raising_external_ref_handler
+        with self.assertRaises(expat.ExpatError):
+            self.assertRaises(TypeError, parse(xml, disable_entities=False, expat=expat))
+        expat.ParserCreate = ParserCreate
+

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -308,7 +308,12 @@ class XMLToDictTestCase(unittest.TestCase):
         <bomb>&c;</bomb>
         """
         expectedResult = {'bomb': None}
-        self.assertEqual(parse(xml, disable_entities=True), expectedResult)
+        try:
+            parse_attempt = parse(xml, disable_entities=True)
+        except expat.ExpatError:
+            self.assertTrue(True)
+        else:
+            self.assertEqual(parse_attempt, expectedResult)
 
     def test_disable_entities_false_returns_xmlbomb(self):
         xml = """
@@ -331,7 +336,12 @@ class XMLToDictTestCase(unittest.TestCase):
         <root>&ee;</root>
         """
         expectedResult = {'root': None}
-        self.assertEqual(parse(xml, disable_entities=True), expectedResult)
+        try:
+            parse_attempt = parse(xml, disable_entities=True)
+        except expat.ExpatError:
+            self.assertTrue(True)
+        else:
+            self.assertEqual(parse_attempt, expectedResult)
 
     def test_disable_entities_true_attempts_external_dtd(self):
         xml = """
@@ -343,6 +353,11 @@ class XMLToDictTestCase(unittest.TestCase):
         def raising_external_ref_handler(*args, **kwargs):
             parser = ParserCreate(*args, **kwargs)
             parser.ExternalEntityRefHandler = lambda *x: 0
+            try:
+                feature = "http://apache.org/xml/features/disallow-doctype-decl"
+                parser._reader.setFeature(feature, True)
+            except AttributeError:
+                pass
             return parser
         expat.ParserCreate = raising_external_ref_handler
         # Using this try/catch because a TypeError is thrown before 

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -306,7 +306,6 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
     parser.CharacterDataHandler = handler.characters
     parser.buffer_text = True
     if disable_entities:
-        parser.UseForeignDTD(False)
         # Anything not handled ends up here and entities aren't expanded.
         parser.DefaultHandler = lambda x: None
         # Expects an integer return; zero means failure -> expat.ExpatError.

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -307,7 +307,9 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
     parser.buffer_text = True
     if disable_entities:
         parser.UseForeignDTD(False)
+        # Anything not handled ends up here and entities aren't expanded.
         parser.DefaultHandler = lambda x: None
+        # Expects an integer return; zero means failure -> expat.ExpatError.
         parser.ExternalEntityRefHandler = lambda *x: 1
     try:
         parser.ParseFile(xml_input)

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -181,7 +181,7 @@ class _DictSAXHandler(object):
 
 
 def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
-          namespace_separator=':', **kwargs):
+          namespace_separator=':', disable_entities=True, **kwargs):
     """Parse the given XML input and convert it into a dictionary.
 
     `xml_input` can either be a `string` or a file-like object.
@@ -305,6 +305,10 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
     parser.EndElementHandler = handler.endElement
     parser.CharacterDataHandler = handler.characters
     parser.buffer_text = True
+    if disable_entities:
+        parser.UseForeignDTD(False)
+        parser.DefaultHandler = lambda x: None
+        parser.ExternalEntityRefHandler = lambda *x: 1
     try:
         parser.ParseFile(xml_input)
     except (TypeError, AttributeError):

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -306,10 +306,17 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
     parser.CharacterDataHandler = handler.characters
     parser.buffer_text = True
     if disable_entities:
-        # Anything not handled ends up here and entities aren't expanded.
-        parser.DefaultHandler = lambda x: None
-        # Expects an integer return; zero means failure -> expat.ExpatError.
-        parser.ExternalEntityRefHandler = lambda *x: 1
+        
+        try:
+            # Attempt to disable DTD in Jython's expat parser (Xerces-J).
+            feature = "http://apache.org/xml/features/disallow-doctype-decl"
+            parser._reader.setFeature(feature, True)
+        except AttributeError:
+            # For CPython / expat parser.
+            # Anything not handled ends up here and entities aren't expanded.
+            parser.DefaultHandler = lambda x: None
+            # Expects an integer return; zero means failure -> expat.ExpatError.
+            parser.ExternalEntityRefHandler = lambda *x: 1
     try:
         parser.ParseFile(xml_input)
     except (TypeError, AttributeError):


### PR DESCRIPTION
This patch adds a default config to the parse function to turn off / disable DTDs / entity expansion / external entity fetching. It is the kind of thing defusedexpat does, except that defusedexpat modifies expat itself and make these features less catastrophic but still available.

The idea is, assuming these problematic features are not something that the casual XML parsing public require (including myself), and that similarly they won't investigate the optional defusedexpat parser dependency (as shown in PR 130), it would be OK to turn off this stuff by default. Users that require it can override this.

The approach taken is similar to that in the Django xml serializer [1], but this patch does not bother to raise errors when undesirable XML content is discarded.

A related issue is that defusedexpat hasn't updated with the recent raft of bugfixes that happened in expat, and doesn't officially support python 3 after 3.3. I worked out how to make defusedexpat work with 3.5 [2] but then noticed all the expat changes and came up with this alternative.

P.S. thanks very much for this library, it has been incredibly useful.

[1] https://github.com/django/django/blob/master/django/core/serializers/xml_serializer.py
[2] Copy ./Modules33 to ./Modules35, then change ./Modules35/pyexpat.c at Line 1193 from "_Py_HashSecret.prefix" to "_Py_HashSecret.expat.hashsalt", then build & install.
