### PR TITLE
Determine fileness by checking for `read` attribute

### DIFF
--- a/xmltodict.py
+++ b/xmltodict.py
@@ -313,9 +313,9 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
     parser.EndElementHandler = handler.endElement
     parser.CharacterDataHandler = handler.characters
     parser.buffer_text = True
-    try:
+    if hasattr(xml_input, 'read'):
         parser.ParseFile(xml_input)
-    except (TypeError, AttributeError):
+    else:
         parser.Parse(xml_input, True)
     return handler.item
 


### PR DESCRIPTION
Currently, `xmltodict` tries to determine whether its input is a file-like object by treating it as a file and, if that fails, treating it as a string.  However, if the input is a file but `item_callback` raises a `TypeError` or `AttributeError` for some reason of its own, the error will be discarded and replaced with the exception "`TypeError: must be string or read-only buffer, not file`", which is confusing and makes debugging harder.

This pull request makes `xmltodict` instead determine fileness by checking for the presence of a `read` attribute, which is the only method `xml.parsers.expat` needs.