### PR TITLE
Use Markdown long_description on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,15 @@ except ImportError:
 
 import xmltodict
 
+with open('README.md') as f:
+    long_description = f.read()
+
+
 setup(name='xmltodict',
       version=xmltodict.__version__,
       description=xmltodict.__doc__,
+      long_description=long_description,
+      long_description_content_type='text/markdown',
       author=xmltodict.__author__,
       author_email='martinblech@gmail.com',
       url='https://github.com/martinblech/xmltodict',


### PR DESCRIPTION
The PyPI listing at https://pypi.org/project/xmltodict/ looks like this:

![image](https://user-images.githubusercontent.com/1324225/45374705-940b7e00-b5fb-11e8-98c7-fd0f10498c85.png)

Good news! The new PyPI (aka Warehouse) now supports Markdown and can show README.md with proper formatting!

Here's info on how to use it (eg. first `pip install -U setuptools wheel twine` and use Twine to upload), and an example:

* https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi
* https://github.com/di/markdown-description-example