### PR TITLE
Fix and simplify travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,30 +7,20 @@ python:
   - "3.6"
   - "pypy"
 
-env:
-  - JYTHON=true
-  - JYTHON=false
-
 matrix:
   include:
     - python: "3.7"
-      env: JYTHON=false
       dist: xenial
       sudo: required
-  exclude:
-    - python: "2.7"
-      env: JYTHON=true
-    - python: "3.4"
-      env: JYTHON=true
-    - python: "3.5"
-      env: JYTHON=true
-    - python: "3.6"
-      env: JYTHON=true
+    - name: "Jython"
+      python: "pypy"
+      env: JYTHON_VERSION="2.7.0"
+      before_install:
+        - export JYTHON_URL="http://search.maven.org/remotecontent?filepath=org/python/jython-installer/${JYTHON_VERSION}/jython-installer-${JYTHON_VERSION}.jar"
+        - wget $JYTHON_URL -O jython_installer.jar
+        - java -jar jython_installer.jar -s -d $HOME/jython
+        - export PATH="$HOME/jython:$PATH"
+        - $HOME/jython/bin/easy_install nose
+      script: $HOME/jython/bin/nosetests
 
-before_install:
-  - export JYTHON_URL='http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.7.0/jython-installer-2.7.0.jar'
-  - if [ "$JYTHON" == "true" ]; then wget $JYTHON_URL -O jython_installer.jar; java -jar jython_installer.jar -s -d $HOME/jython; export PATH=$HOME/jython:$PATH; jython ez_setup.py; $HOME/jython/bin/easy_install nose; fi
-
-before_script: if [ "$JYTHON" == "true" ]; then export NOSE=$HOME/jython/bin/nosetests NOSE_OPTIONS=""; else export NOSE=nosetests NOSE_OPTIONS="--with-coverage --cover-package=xmltodict"; fi
-
-script: $NOSE $NOSE_OPTIONS
+script: nosetests --with-coverage --cover-package=xmltodict


### PR DESCRIPTION
`JYTHON=true` was only used once and excluded in all other cases.

`jython ez_setup.py` failed without causing the build to fail, see eg. https://travis-ci.org/martinblech/xmltodict/jobs/427429418#L487. When changing that to `$HOME/jython/bin/jython ez_setup.py` the next step (`easy_install nose`) failed.  After removing the command alltogether it worked.

This PR does *not* address `nose.plugins.cover: ERROR: Coverage not available: unable to import coverage module`.