### PR TITLE
Allow force_list=True for getting all keys as lists

### DIFF
--- a/xmltodict.py
+++ b/xmltodict.py
@@ -176,6 +176,8 @@ class _DictSAXHandler(object):
     def _should_force_list(self, key, value):
         if not self.force_list:
             return False
+        if isinstance(self.force_list, bool):
+            return self.force_list
         try:
             return key in self.force_list
         except TypeError:


### PR DESCRIPTION
This allows the optional `force_list` parameter in `xmltodict.parse() ` to accept `True` as a valid input value which then allows to receive all text node values of an xml as lists, even if a node contains only a single child.
See my question in [#14](https://github.com/martinblech/xmltodict/issues/14#issuecomment-458893210) and the great answer of [candlerb](https://github.com/martinblech/xmltodict/issues/14#issuecomment-458899357).