### PR TITLE
Support defaultdict for namespace mapping

### DIFF
--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -1,4 +1,5 @@
 from xmltodict import parse, ParsingInterrupted
+import collections
 import unittest
 
 try:
@@ -222,6 +223,35 @@ class XMLToDictTestCase(unittest.TestCase):
                 },
                 'ns_a:y': '2',
                 'http://b.com/:z': '3',
+            },
+        }
+        res = parse(xml, process_namespaces=True, namespaces=namespaces)
+        self.assertEqual(res, d)
+
+    def test_namespace_collapse_all(self):
+        xml = """
+        <root xmlns="http://defaultns.com/"
+              xmlns:a="http://a.com/"
+              xmlns:b="http://b.com/">
+          <x a:attr="val">1</x>
+          <a:y>2</a:y>
+          <b:z>3</b:z>
+        </root>
+        """
+        namespaces = collections.defaultdict(lambda: None)
+        d = {
+            'root': {
+                'x': {
+                    '@xmlns': {
+                        '': 'http://defaultns.com/',
+                        'a': 'http://a.com/',
+                        'b': 'http://b.com/',
+                    },
+                    '@attr': 'val',
+                    '#text': '1',
+                },
+                'y': '2',
+                'z': '3',
             },
         }
         res = parse(xml, process_namespaces=True, namespaces=namespaces)

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -70,13 +70,16 @@ class _DictSAXHandler(object):
         self.force_list = force_list
 
     def _build_name(self, full_name):
-        if not self.namespaces:
+        if self.namespaces is None:
             return full_name
         i = full_name.rfind(self.namespace_separator)
         if i == -1:
             return full_name
         namespace, name = full_name[:i], full_name[i+1:]
-        short_namespace = self.namespaces.get(namespace, namespace)
+        try:
+            short_namespace = self.namespaces[namespace]
+        except KeyError:
+            short_namespace = namespace
         if not short_namespace:
             return name
         else:


### PR DESCRIPTION
In my use case, I want to ignore all namespaces. I hoped I could do this by using a [defaultdict](https://docs.python.org/3.7/library/collections.html#collections.defaultdict) which returned `None` for all keys, but two minor issues in the code (see comments inline) prevented this from working as you would expect.

With this change, the following works:

```python
>>> import collections
>>> xml = """
... <root xmlns="http://defaultns.com/"
...       xmlns:a="http://a.com/"
...       xmlns:b="http://b.com/">
...   <x>1</x>
...   <a:y>2</a:y>
...   <b:z>3</b:z>
... </root>
... """
>>> namespaces = collections.defaultdict(lambda: None)
>>> xmltodict.parse(xml, process_namespaces=True, namespaces=namespaces) == {
...     'root': {
...         'x': '1',
...         'y': '2',
...         'z': '3',
...     },
... }
True
```