### PR TITLE
parse(generator) is now possible

### DIFF
--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -120,6 +120,17 @@ class XMLToDictTestCase(unittest.TestCase):
                           parse, '<a>x</a>',
                           item_depth=1, item_callback=cb)
 
+    def test_streaming_generator(self):
+        def cb(path, item):
+            cb.count += 1
+            self.assertEqual(path, [('a', {'x': 'y'}), ('b', None)])
+            self.assertEqual(item, str(cb.count))
+            return True
+        cb.count = 0
+        parse((n for n in '<a x="y"><b>1</b><b>2</b><b>3</b></a>'),
+              item_depth=2, item_callback=cb)
+        self.assertEqual(cb.count, 3)
+
     def test_postprocessor(self):
         def postprocessor(path, key, value):
             try:

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -16,6 +16,7 @@ except ImportError:  # pragma no cover
         from io import StringIO
 
 from collections import OrderedDict
+from inspect import isgenerator
 
 try:  # pragma no cover
     _basestring = basestring
@@ -191,7 +192,7 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
           namespace_separator=':', disable_entities=True, **kwargs):
     """Parse the given XML input and convert it into a dictionary.
 
-    `xml_input` can either be a `string` or a file-like object.
+    `xml_input` can either be a `string`, a file-like object, or a generator of strings.
 
     If `xml_attribs` is `True`, element attributes are put in the dictionary
     among regular child elements, using `@` as a prefix to avoid collisions. If
@@ -326,6 +327,10 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
             parser.ExternalEntityRefHandler = lambda *x: 1
     if hasattr(xml_input, 'read'):
         parser.ParseFile(xml_input)
+    elif isgenerator(xml_input):
+        for chunk in xml_input:
+            parser.Parse(chunk,False)
+        parser.Parse(b'',True)
     else:
         parser.Parse(xml_input, True)
     return handler.item


### PR DESCRIPTION
* This can be useful to parse a request from the requests library using
iter_content().
* Also add a test to confirm that generator works.

I also found a problem with file-like objects where some data appears to get stuck in the internal buffer and doesn't get pushed out until more data comes in. This was a problem for us as we're streaming and want the callback to get called as soon as the close tag finishes (the server waits a bit after the close tag to send more data). I was able to work around this problem using the generators here.