### PR TITLE
Add expand_iter kw to unparse to expand iterables

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,37 @@ Text values for nodes can be specified with the `cdata_key` key in the python di
 <text stroke="2" color="red">This is a test</text>
 ```
 
+Lists that are specified under a key in a dictionary use the key as a tag for each item. But if a list does have a parent key, for example if a list exists inside another list, it does not have a tag to use and the items are converted to a string as shown in the example below.  To give tags to nested lists, use the `expand_iter` keyword argument to provide a tag as demonstrated below. Note that using `expand_iter` will break roundtripping.
+
+```python
+>>> mydict = {
+...     "line": {
+...         "points": [
+...             [1, 5],
+...             [2, 6],
+...         ]
+...     }
+... }
+>>> print(xmltodict.unparse(mydict, pretty=True))
+<?xml version="1.0" encoding="utf-8"?>
+<line>
+        <points>[1, 5]</points>
+        <points>[2, 6]</points>
+</line>
+>>> print(xmltodict.unparse(mydict, pretty=True, expand_iter="coord"))
+<?xml version="1.0" encoding="utf-8"?>
+<line>
+        <points>
+                <coord>1</coord>
+                <coord>5</coord>
+        </points>
+        <points>
+                <coord>2</coord>
+                <coord>6</coord>
+        </points>
+</line>
+```
+
 ## Ok, how do I get it?
 
 ### Using pypi

--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -46,6 +46,14 @@ class DictToXMLTestCase(unittest.TestCase):
         self.assertEqual(obj, parse(unparse(obj)))
         self.assertEqual(unparse(obj), unparse(parse(unparse(obj))))
 
+    def test_list_expand_iter(self):
+        obj = {'a': {'b': [['1', '2'], ['3',]]}}
+        #self.assertEqual(obj, parse(unparse(obj, expand_iter="item")))
+        exp_xml = dedent('''\
+        <?xml version="1.0" encoding="utf-8"?>
+        <a><b><item>1</item><item>2</item></b><b><item>3</item></b></a>''')
+        self.assertEqual(exp_xml, unparse(obj, expand_iter="item"))
+
     def test_generator(self):
         obj = {'a': {'b': ['1', '2', '3']}}
 

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -400,7 +400,8 @@ def _emit(key, value, content_handler,
           indent='\t',
           namespace_separator=':',
           namespaces=None,
-          full_document=True):
+          full_document=True,
+          expand_iter=None):
     key = _process_namespace(key, namespaces, namespace_separator, attr_prefix)
     if preprocessor is not None:
         result = preprocessor(key, value)
@@ -422,7 +423,10 @@ def _emit(key, value, content_handler,
             else:
                 v = _unicode('false')
         elif not isinstance(v, dict):
-            v = _unicode(v)
+            if expand_iter and hasattr(v, '__iter__') and not isinstance(v, _basestring):
+                v = OrderedDict(((expand_iter, v),))
+            else:
+                v = _unicode(v)
         if isinstance(v, _basestring):
             v = OrderedDict(((cdata_key, v),))
         cdata = None
@@ -454,7 +458,8 @@ def _emit(key, value, content_handler,
             _emit(child_key, child_value, content_handler,
                   attr_prefix, cdata_key, depth+1, preprocessor,
                   pretty, newl, indent, namespaces=namespaces,
-                  namespace_separator=namespace_separator)
+                  namespace_separator=namespace_separator,
+                  expand_iter=expand_iter)
         if cdata is not None:
             content_handler.characters(cdata)
         if pretty and children:


### PR DESCRIPTION
Add `expand_iter` kwarg to unparse that will expand lists into sets of XML elements rather than outputting the string representation of the list

This is more of a proposal than actual PR - I should probably update the README and add a test.  But before doing that I wanted to submit this.

Using a simple dict:

    test_dict = {'root': {'imgs': ((1, 2), (3, 4))}}

Output before the change/with out the flag:

    print(xmltodict.unparse(test_dict, pretty=True))
    <?xml version="1.0" encoding="utf-8"?>
    <root>
    	<imgs>(1, 2)</imgs>
    	<imgs>(3, 4)</imgs>
    </root>

After:

    print(xmltodict.unparse(test_dict, expand_iter="item", pretty=True))
    <?xml version="1.0" encoding="utf-8"?>
    <root>
    	<imgs>
    		<item>1</item>
    		<item>2</item>
    	</imgs>
    	<imgs>
    		<item>3</item>
    		<item>4</item>
    	</imgs>
    </root>