### PR TITLE
Fix UnicodeDecodeError with Python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,10 @@ except ImportError:
 
 import xmltodict
 
-with open('README.md') as f:
+import io
+import os
+here = os.path.abspath(os.path.dirname(__file__))
+with io.open(os.path.join(here, 'README.md'), encoding='utf8') as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
```
python3.6 -B setup.py config

Traceback (most recent call last):
  File "setup.py", line 12, in <module>
    long_description = f.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2587: ordinal not in range(128)
```