### PR TITLE
Support indent by number

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -136,6 +136,26 @@ class DictToXMLTestCase(unittest.TestCase):
         self.assertEqual(xml, unparse(obj, pretty=True,
                                       newl=newl, indent=indent))
 
+    def test_pretty_print_with_int_indent(self):
+        obj = {'a': OrderedDict((
+            ('b', [{'c': [1, 2]}, 3]),
+            ('x', 'y'),
+        ))}
+        newl = '\n'
+        indent = 2
+        xml = dedent('''\
+        <?xml version="1.0" encoding="utf-8"?>
+        <a>
+          <b>
+            <c>1</c>
+            <c>2</c>
+          </b>
+          <b>3</b>
+          <x>y</x>
+        </a>''')
+        self.assertEqual(xml, unparse(obj, pretty=True,
+                                      newl=newl, indent=indent))
+
     def test_encoding(self):
         try:
             value = unichr(39321)

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -445,6 +445,8 @@ def _emit(key, value, content_handler,
                 attrs[ik[len(attr_prefix):]] = iv
                 continue
             children.append((ik, iv))
+        if type(indent) is int:
+            indent = ' ' * indent
         if pretty:
             content_handler.ignorableWhitespace(depth * indent)
         content_handler.startElement(key, AttributesImpl(attrs))


### PR DESCRIPTION
Originally `unparse(mydict, pretty=True, indent=2)` would fail with confusing error message,
as it only supported `unparse(mydict, pretty=True, indent='  ')`

This is not documented and prone to confusion, especially because there is a code snippet using int `indent` excerpted from [README.md](https://github.com/martinblech/xmltodict/blob/9c2b733/README.md#xmltodict).
```python
>>> print(json.dumps(xmltodict.parse("""
...  <mydocument has="an attribute">
...    <and>
...      <many>elements</many>
...      <many>more elements</many>
...    </and>
...    <plus a="complex">
...      element as well
...    </plus>
...  </mydocument>
...  """), indent=4))
{
    "mydocument": {
        "@has": "an attribute", 
        "and": {
            "many": [
                "elements", 
                "more elements"
            ]
        }, 
        "plus": {
            "@a": "complex", 
            "#text": "element as well"
        }
    }
}
```

This commit adds support for int `indent`.