### PR TITLE
add flag to strip namespaces

### DIFF
--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -207,6 +207,34 @@ class XMLToDictTestCase(unittest.TestCase):
         res = parse(xml, process_namespaces=True)
         self.assertEqual(res, d)
 
+    def test_namespace_strip(self):
+        xml = """
+        <root xmlns="http://defaultns.com/"
+              xmlns:a="http://a.com/"
+              xmlns:b="http://b.com/">
+          <x a:attr="val">1</x>
+          <a:y>2</a:y>
+          <b:z>3</b:z>
+        </root>
+        """
+        d = {
+            'root': {
+                'x': {
+                    '@attr': 'val',
+                    '@xmlns': {
+                        '': 'http://defaultns.com/',
+                        'a': 'http://a.com/',
+                        'b': 'http://b.com/',
+                    },
+                    '#text': '1',
+                },
+                'y': '2',
+                'z': '3',
+            },
+        }
+        res = parse(xml, process_namespaces=True, strip_namespaces=True)
+        self.assertDictEqual(res, d)
+
     def test_namespace_collapse(self):
         xml = """
         <root xmlns="http://defaultns.com/"
@@ -237,6 +265,9 @@ class XMLToDictTestCase(unittest.TestCase):
             },
         }
         res = parse(xml, process_namespaces=True, namespaces=namespaces)
+        self.assertTrue('root' in res)
+        self.assertTrue('x' in res['root'])
+        self.assertTrue('@xmlns' in res['root']['x'])
         self.assertEqual(res, d)
 
     def test_namespace_collapse_all(self):

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -51,7 +51,9 @@ class _DictSAXHandler(object):
                  namespace_separator=':',
                  namespaces=None,
                  force_list=None,
-                 comment_key='#comment'):
+                 comment_key='#comment',
+                 strip_namespaces=False
+                 ):
         self.path = []
         self.stack = []
         self.data = []
@@ -71,14 +73,17 @@ class _DictSAXHandler(object):
         self.namespace_declarations = OrderedDict()
         self.force_list = force_list
         self.comment_key = comment_key
+        self.strip_namespaces = strip_namespaces
 
     def _build_name(self, full_name):
-        if self.namespaces is None:
+        if self.namespaces is None and not self.strip_namespaces:
             return full_name
         i = full_name.rfind(self.namespace_separator)
         if i == -1:
             return full_name
         namespace, name = full_name[:i], full_name[i+1:]
+        if self.strip_namespaces:
+            return name
         try:
             short_namespace = self.namespaces[namespace]
         except KeyError:


### PR DESCRIPTION
`parse(xml, process_namespaces=True, strip_namespaces=True)` will now strip all namespaces out of the output.