### PR TITLE
fix attributes not appearing in streaming mode

### DIFF
--- a/xmltodict.py
+++ b/xmltodict.py
@@ -103,7 +103,7 @@ class _DictSAXHandler(object):
             attrs['xmlns'] = self.namespace_declarations
             self.namespace_declarations = OrderedDict()
         self.path.append((name, attrs or None))
-        if len(self.path) > self.item_depth:
+        if len(self.path) >= self.item_depth:
             self.stack.append((self.item, self.data))
             if self.xml_attribs:
                 attr_entries = []
@@ -368,8 +368,8 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
         parser.ParseFile(xml_input)
     elif isgenerator(xml_input):
         for chunk in xml_input:
-            parser.Parse(chunk,False)
-        parser.Parse(b'',True)
+            parser.Parse(chunk, False)
+        parser.Parse(b'', True)
     else:
         parser.Parse(xml_input, True)
     return handler.item


### PR DESCRIPTION
#183 attributes not appearing in parse output even with xml_attribs = True
```
body ='''<api>
<cons id="79550" modified_dt="1526652449">
<firstname>Mackenzie</firstname>
</cons>
<cons id="79551" modified_dt="1526652549">
<firstname>Joe</firstname>
</cons>
<api>'''

items = []
def handler(path, item):
  items.append(item)
xmltodict.parse(body, item_depth=2, item_callback=handler)

Results:
items = [
{
 '@id': '79550',
'@modified_dt': '1526652449',
'firstname': 'Mackenzie',
},
{
 '@id': '79551',
'@modified_dt': '1526652549',
'firstname': 'Joe',
}
]```