### PR TITLE
Fix UnicodeDecodeError with python3 and no utf-8 locale installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ except ImportError:
 
 import xmltodict
 
-with open('README.md') as f:
-    long_description = f.read()
+with open('README.md', 'rb') as f:
+    long_description = f.read().decode('utf-8')
 
 
 setup(name='xmltodict',


### PR DESCRIPTION
With python3, the built-in `open()` function opens files in "text" mode by default (i.e. the `f.read()` method reads bytes and tries to decode them to unicode using the interpreter default encoding). Depending on the system locale, this default encoding may be `'ascii'`. Which leads to the following error:

```
~$ python3 setup.py egg_info
Traceback (most recent call last):
  File "setup.py", line 12, in <module>
    long_description = f.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2587: ordinal not in range(128)
```

The character at position 2587 is `ô` (from `Fantômas`) and is utf-8 encoded.

Force to open the file in "binary" mode (which is the only mode on python2) and explicitly decode the read bytes to unicode using the `'utf-8'` codec.

Fixes: 8374e7d84f92 ("Use Markdown long_description on PyPI (#190)")