### PR TITLE
Support defaultdict as dict_constructor

### DIFF
--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -475,3 +475,12 @@ class XMLToDictTestCase(unittest.TestCase):
             return True
 
         parse(xml, item_depth=2, item_callback=handler)
+
+    def test_defaultdict_as_dict_constructor(self):
+        xml = """
+        <root>a</root>
+        """
+        expectedResult = {'root': 'a'}
+        def dict_constructor(*args, **kwargs):
+            return collections.defaultdict(lambda: None, *args, **kwargs)
+        self.assertEqual(dict(parse(xml, dict_constructor=dict_constructor)), expectedResult)

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -175,17 +175,17 @@ class _DictSAXHandler(object):
             key, data = result
         if item is None:
             item = self.dict_constructor()
-        if key in item:
-            value = item[key]
-            if isinstance(value, list):
-                value.append(data)
-            else:
-                item[key] = [value, data]
-        else:
+        not_present = object() # guaranteed to not be in <item>
+        value = item.get(key, not_present)
+        if value is not_present:
             if self._should_force_list(key, data):
                 item[key] = [data]
             else:
                 item[key] = data
+        elif isinstance(value, list):
+            value.append(data)
+        else:
+            item[key] = [value, data]
         return item
 
     def _should_force_list(self, key, value):

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -175,13 +175,13 @@ class _DictSAXHandler(object):
             key, data = result
         if item is None:
             item = self.dict_constructor()
-        try:
+        if key in item:
             value = item[key]
             if isinstance(value, list):
                 value.append(data)
             else:
                 item[key] = [value, data]
-        except KeyError:
+        else:
             if self._should_force_list(key, data):
                 item[key] = [data]
             else:


### PR DESCRIPTION
Addresses #255 by checking explicitly if key is already seen, instead of catching KeyError.

The failing test is added in the first commit, to make it clear what is fixed.