### PR TITLE
added option to convert dictionary values from strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+Unreleased
+----------
+* Allow convert_values=True for converting dictionary values from strings
+
 v0.12.0
 -------
 

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -449,3 +449,25 @@ class XMLToDictTestCase(unittest.TestCase):
             }
         }
         self.assertEqual(parse(xml, process_comments=True), expectedResult)
+
+    def test_convert_values(self):
+        xml = """
+        <a>
+            <b> 1.23 </b>
+            <c> alpha <c>
+            <d>
+                <e> [2, abc] </e>
+                <f> True </f>
+            </d>
+            <g> (NH4)3PO4, (i.e., amonium phosphate) </g>
+        </a>
+        """
+        expectedResult = {
+            'a': {
+                'b': 1.23,
+                'c': 'alpha',
+                'd': {'e': [2, 'abc'], 'f': True},
+                'g': '(NH4)3PO4, (i.e., amonium phosphate)',
+                },
+        }
+        self.assertEqual(parse(xml, convert_values=True), expectedResult)

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -28,7 +28,7 @@ except NameError:  # pragma no cover
     _unicode = str
 
 __author__ = 'Martin Blech'
-__version__ = '0.13.0'
+__version__ = '0.12.0'
 __license__ = 'MIT'
 
 


### PR DESCRIPTION
Added code to interpret strings in the dictionary value field to be interpreted as Python values (int, float, bool, etc). Default behavior remains unchanged, this additional step only occurs if `convert_values=True` in the `parse` function.

An example has been added to the `parse` docstring and to the list of unit tests.

PR is set as draft since I could not run tox on my local machine. I'll wait for Travis to run the tests and convert from draft to full PR once it's passing.