### PR TITLE
Ensure significant whitespace is not trimmed

### DIFF
--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -93,13 +93,13 @@ class XMLToDictTestCase(unittest.TestCase):
         """
         self.assertEqual(
             parse(xml),
-            {'root': {'emptya': None,
+            {'root': {'emptya': "           ",
                       'emptyb': {'@attr': 'attrvalue'},
                       'value': 'hello'}})
 
     def test_keep_whitespace(self):
         xml = "<root> </root>"
-        self.assertEqual(parse(xml), dict(root=None))
+        self.assertEqual(parse(xml), dict(root=' '))
         self.assertEqual(parse(xml, strip_whitespace=False),
                          dict(root=' '))
 

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -137,7 +137,7 @@ class _DictSAXHandler(object):
                     else self.cdata_separator.join(self.data))
             item = self.item
             self.item, self.data = self.stack.pop()
-            if self.strip_whitespace and data:
+            if self.strip_whitespace and data and item:
                 data = data.strip() or None
             if data and self.force_cdata and item is None:
                 item = self.dict_constructor()


### PR DESCRIPTION
This PR should address #264 

I think `xmltodict` has been improperly handling significant whitespace by default when `strip_whitespace=True`. If the whitespace is part of a leaf node, it should be preserved, whereas whitespace elsewhere in the document can be safely removed. I also adjusted some of the existing tests to reflect this change. [This page](http://usingxml.com/Basics/XmlSpace) illustrates the difference.