### PR TITLE
Do not use `len()` to determine if a sequence is empty

### DIFF
--- a/xmltodict.py
+++ b/xmltodict.py
@@ -132,7 +132,7 @@ class _DictSAXHandler(object):
             should_continue = self.item_callback(self.path, item)
             if not should_continue:
                 raise ParsingInterrupted()
-        if len(self.stack):
+        if self.stack:
             data = (None if not self.data
                     else self.cdata_separator.join(self.data))
             item = self.item


### PR DESCRIPTION
Fixes a DeepSource.io alert:

> Using the `len` function to check if a sequence is empty is not idiomatic and can be less performant than checking the truthiness of the object.
> 
> `len` doesn't know the context in which it is called, so if computing the length means traversing the entire sequence, it must; it doesn't know that the result is just being compared to 0. Computing the boolean value can stop after it sees the first element, regardless of how long the sequence actually is.

Not an actual issue here - just trying to avoid alerts from automated reviewing tools.