### PR TITLE
fix for #282

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -213,3 +213,51 @@ xmlns:b="http://b.com/"><x a:attr="val">1</x><a:y>2</a:y><b:z>3</b:z></root>'''
         expected_xml = '<?xml version="1.0" encoding="utf-8"?>\n<x>false</x>'
         xml = unparse(dict(x=False))
         self.assertEqual(xml, expected_xml)
+
+    def test_text_part(self):
+        obj = OrderedDict((
+            ('a', OrderedDict((
+                ('b', 'text'),
+                ('#text', 'end'),
+            ))),
+        ))
+        expected_xml = '<?xml version="1.0" encoding="utf-8"?>\n<a><b>text</b>end</a>'
+        xml = unparse(obj)
+        self.assertEqual(xml, expected_xml)
+
+    def test_comment_part(self):
+        obj = OrderedDict((
+            ('a', OrderedDict((
+                ('b', 'text'),
+                ('#comment', 'remark'),
+            ))),
+        ))
+        # we expect comments to be ignored in the output
+        expected_xml = '<?xml version="1.0" encoding="utf-8"?>\n<a><b>text</b></a>'
+        xml = unparse(obj)
+        self.assertEqual(xml, expected_xml)
+
+    def test_mixed_content(self):
+        obj = OrderedDict((
+            ('a', OrderedDict((
+                ('#text', 'before'),
+                ('b', 'text'),
+                ('#text1', 'after'),
+            ))),
+        ))
+        expected_xml = '<?xml version="1.0" encoding="utf-8"?>\n<a>before<b>text</b>after</a>'
+        xml = unparse(obj)
+        self.assertEqual(xml, expected_xml)
+
+    def test_multiple_comments(self):
+        obj = OrderedDict((
+            ('a', OrderedDict((
+                ('#comment', '1st'),
+                ('b', 'text'),
+                ('#comment1', '2nd'),
+            ))),
+        ))
+        # we expect comments to be ignored in the output
+        expected_xml = '<?xml version="1.0" encoding="utf-8"?>\n<a><b>text</b></a>'
+        xml = unparse(obj)
+        self.assertEqual(xml, expected_xml)

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -477,13 +477,13 @@ class XMLToDictTestCase(unittest.TestCase):
 
     def test_mixed_content(self):
         xml = """
-        <a>prefix text<b>nested element text</b>suffix text</a>
+        <a>prefix text <b>nested element text</b> suffix text</a>
         """
         expectedResult = {
             'a': {
-                '#text': 'prefix text',
+                '#text': 'prefix text ',
                 'b': 'nested element text',
-                '#text1': 'suffix text',
+                '#text1': ' suffix text',
             }
         }
         import json

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -449,3 +449,43 @@ class XMLToDictTestCase(unittest.TestCase):
             }
         }
         self.assertEqual(parse(xml, process_comments=True), expectedResult)
+
+    def test_multiple_comments(self):
+        xml = """
+        <a>
+          <b>
+            <!-- 1st comment -->
+            <c>1</c>
+            <!-- 2nd comment -->
+            <d>2</d>
+          </b>
+        </a>
+        """
+        expectedResult = {
+            'a': {
+                'b': {
+                    '#comment': '1st comment',
+                    'c': '1',
+                    '#comment1': '2nd comment',
+                    'd': '2',
+                },
+            }
+        }
+        import json
+        print(json.dumps(parse(xml, process_comments=True)))
+        self.assertEqual(parse(xml, process_comments=True), expectedResult)
+
+    def test_mixed_content(self):
+        xml = """
+        <a>prefix text<b>nested element text</b>suffix text</a>
+        """
+        expectedResult = {
+            'a': {
+                '#text': 'prefix text',
+                'b': 'nested element text',
+                '#text1': 'suffix text',
+            }
+        }
+        import json
+        print(json.dumps(parse(xml, mixed_content=True)))
+        self.assertEqual(parse(xml, mixed_content=True), expectedResult)

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -109,7 +109,6 @@ class _DictSAXHandler(object):
                 item = self.item
                 if item is None:
                     item = self.dict_constructor()
-                print(f"pushing cdata {data}")
                 self.item = self.push_data(item, self.cdata_key, data)
             self.data=[]
 

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -102,9 +102,7 @@ class _DictSAXHandler(object):
         # if a new element starts in mixed_content modus, we should chek if there is ongoing data
         if self.mixed_content and len(self.data):  # a new element starts within the content of another --> mixed content model
             # we should close up the previous
-            data = self.cdata_separator.join(self.data)
-            if self.strip_whitespace:
-                data = data.strip()
+            data = self.cdata_separator.join(self.data) # note: never strip spaces when dealing with mixed_content
             if len(data):  # doesn't make sense to push empty string through
                 item = self.item
                 if item is None:
@@ -152,12 +150,16 @@ class _DictSAXHandler(object):
                     else self.cdata_separator.join(self.data))
             item = self.item
             self.item, self.data = self.stack.pop()
+            if self.mixed_content:
+                unstripped_data = data or None
             if self.strip_whitespace and data:
                 data = data.strip() or None
             if data and self.force_cdata and item is None:
                 item = self.dict_constructor()
             if item is not None:
-                if data:
+                if self.mixed_content and unstripped_data:
+                    self.push_data(item, self.cdata_key, unstripped_data)
+                elif data:
                     self.push_data(item, self.cdata_key, data)
                 self.item = self.push_data(self.item, name, item)
             else:


### PR DESCRIPTION
This adds support for mixed-content-model parsing.

As per suggestion in the discussion of #282 
While at it, a similar supporting distinction for comments was added to.

The pull-request also adds the extra tests to verify operation.