### PR TITLE
Replace deprecated BadZipfile with BadZipFile

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -110,7 +110,7 @@ def archive_context(filename):
         try:
             with ContextualZipFile(filename) as archive:
                 archive.extractall()
-        except zipfile.BadZipfile as err:
+        except zipfile.BadZipFile as err:
             if not err.args:
                 err.args = ('', )
             err.args = err.args + (


### PR DESCRIPTION
`BadZipfile` (with a small `f`) has been deprecated since Python 3.2, use `BadZipFile` (big `F`) instead, added in 3.2.

* https://docs.python.org/3/library/zipfile.html#zipfile.BadZipfile
* https://github.com/python/cpython/issues/86437