### PR TITLE
Remove defusedexpat import.

### DIFF
--- a/xmltodict.py
+++ b/xmltodict.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 "Makes working with XML feel like you are working with JSON"
 
-try:
-    from defusedexpat import pyexpat as expat
-except ImportError:
-    from xml.parsers import expat
+from xml.parsers import expat
 from xml.sax.saxutils import XMLGenerator
 from xml.sax.xmlreader import AttributesImpl
 try:  # pragma no cover


### PR DESCRIPTION
In the past defusedexpat would protect against certain classes of XML attacks, but defusedexpat is no longer maintained.

A followup project defusedxml exists, but it is no longer needed. The types of vulnerabilities that defusedexpat/defusedxml prevented are already mitigated by fixes within expat itself and newer python versions. See discussion in issue #321 for details.