### PR TITLE
Apply ruff/pyupgrade rules (UP)

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -131,7 +131,7 @@ def archive_context(filename):
 
 def _do_download(version, download_base, to_dir, download_delay):
     """Download Setuptools."""
-    py_desig = 'py{sys.version_info[0]}.{sys.version_info[1]}'.format(sys=sys)
+    py_desig = f'py{sys.version_info[0]}.{sys.version_info[1]}'
     tp = 'setuptools-{version}-{py_desig}.egg'
     egg = os.path.join(to_dir, tp.format(**locals()))
     if not os.path.exists(egg):
@@ -345,7 +345,7 @@ def download_setuptools(
     """
     # making sure we use the absolute path
     to_dir = os.path.abspath(to_dir)
-    zip_name = "setuptools-{}.zip".format(version)
+    zip_name = f"setuptools-{version}.zip"
     url = download_base + zip_name
     saveto = os.path.join(to_dir, zip_name)
     if not os.path.exists(saveto):  # Avoid repeated downloads

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -92,7 +92,7 @@ class ContextualZipFile(zipfile.ZipFile):
         """Construct a ZipFile or ContextualZipFile as appropriate."""
         if hasattr(zipfile.ZipFile, '__exit__'):
             return zipfile.ZipFile(*args, **kwargs)
-        return super(ContextualZipFile, cls).__new__(cls)
+        return super().__new__(cls)
 
 
 @contextlib.contextmanager

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -245,8 +245,7 @@ def download_file_powershell(url, target):
     ps_cmd = (
         "[System.Net.WebRequest]::DefaultWebProxy.Credentials = "
         "[System.Net.CredentialCache]::DefaultCredentials; "
-        '(new-object System.Net.WebClient).DownloadFile("%(url)s", "%(target)s")'
-        % locals()
+        '(new-object System.Net.WebClient).DownloadFile("{url}", "{target}")'.format(**locals())
     )
     cmd = [
         'powershell',
@@ -346,7 +345,7 @@ def download_setuptools(
     """
     # making sure we use the absolute path
     to_dir = os.path.abspath(to_dir)
-    zip_name = "setuptools-%s.zip" % version
+    zip_name = "setuptools-{}.zip".format(version)
     url = download_base + zip_name
     saveto = os.path.join(to_dir, zip_name)
     if not os.path.exists(saveto):  # Avoid repeated downloads

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -75,7 +75,7 @@ def _build_egg(egg, archive_filename, to_dir):
     # returning the result
     log.warn(egg)
     if not os.path.exists(egg):
-        raise IOError('Could not build the egg.')
+        raise OSError('Could not build the egg.')
 
 
 class ContextualZipFile(zipfile.ZipFile):

--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -191,8 +191,6 @@ class DictToXMLTestCase(unittest.TestCase):
         self.assertEqual('<a attr="1"></a>', _strip(unparse(obj)))
 
     def test_short_empty_elements(self):
-        if sys.version_info[0] < 3:
-            return
         obj = {'a': None}
         self.assertEqual('<a/>', _strip(unparse(obj, short_empty_elements=True)))
 

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -168,14 +168,14 @@ class XMLToDictTestCase(unittest.TestCase):
         except NameError:
             value = chr(39321)
         self.assertEqual({'a': value},
-                         parse('<a>%s</a>' % value))
+                         parse('<a>{}</a>'.format(value)))
 
     def test_encoded_string(self):
         try:
             value = unichr(39321)
         except NameError:
             value = chr(39321)
-        xml = '<a>%s</a>' % value
+        xml = '<a>{}</a>'.format(value)
         self.assertEqual(parse(xml),
                          parse(xml.encode('utf-8')))
 

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -168,14 +168,14 @@ class XMLToDictTestCase(unittest.TestCase):
         except NameError:
             value = chr(39321)
         self.assertEqual({'a': value},
-                         parse('<a>{}</a>'.format(value)))
+                         parse(f'<a>{value}</a>'))
 
     def test_encoded_string(self):
         try:
             value = unichr(39321)
         except NameError:
             value = chr(39321)
-        xml = '<a>{}</a>'.format(value)
+        xml = f'<a>{value}</a>'
         self.assertEqual(parse(xml),
                          parse(xml.encode('utf-8')))
 

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -440,7 +440,7 @@ def _emit(key, value, content_handler,
                                         attr_prefix)
                 if ik == '@xmlns' and isinstance(iv, dict):
                     for k, v in iv.items():
-                        attr = 'xmlns{}'.format(':{}'.format(k) if k else '')
+                        attr = 'xmlns{}'.format(f':{k}' if k else '')
                         attrs[attr] = _unicode(v)
                     continue
                 if not isinstance(iv, _unicode):


### PR DESCRIPTION
**⚠** f-strings were introduced in **Python 3.6**. Do you really want to keep Python 3.4 compatibility?