### PR TITLE
Get rid of Python 2 basestring and unicode

### DIFF
--- a/xmltodict.py
+++ b/xmltodict.py
@@ -19,15 +19,6 @@ if tuple(map(int, platform.python_version_tuple()[:2])) < (3, 7):
 
 from inspect import isgenerator
 
-try:  # pragma no cover
-    _basestring = basestring
-except NameError:  # pragma no cover
-    _basestring = str
-try:  # pragma no cover
-    _unicode = unicode
-except NameError:  # pragma no cover
-    _unicode = str
-
 __author__ = 'Martin Blech'
 __version__ = '0.13.0'
 __license__ = 'MIT'
@@ -332,9 +323,8 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
     """
     handler = _DictSAXHandler(namespace_separator=namespace_separator,
                               **kwargs)
-    if isinstance(xml_input, _unicode):
-        if not encoding:
-            encoding = 'utf-8'
+    if isinstance(xml_input, str):
+        encoding = encoding or 'utf-8'
         xml_input = xml_input.encode(encoding)
     if not process_namespaces:
         namespace_separator = None
@@ -409,7 +399,7 @@ def _emit(key, value, content_handler,
         if result is None:
             return
         key, value = result
-    if not hasattr(value, '__iter__') or isinstance(value, (_basestring, dict)):
+    if not hasattr(value, '__iter__') or isinstance(value, (str, dict)):
         value = [value]
     for index, v in enumerate(value):
         if full_document and depth == 0 and index > 0:
@@ -417,16 +407,13 @@ def _emit(key, value, content_handler,
         if v is None:
             v = _dict()
         elif isinstance(v, bool):
-            if v:
-                v = _unicode('true')
-            else:
-                v = _unicode('false')
-        elif not isinstance(v, dict):
-            if expand_iter and hasattr(v, '__iter__') and not isinstance(v, _basestring):
+            v = 'true' if v else 'false'
+        elif not isinstance(v, (dict, str)):
+            if expand_iter and hasattr(v, '__iter__'):
                 v = _dict(((expand_iter, v),))
             else:
-                v = _unicode(v)
-        if isinstance(v, _basestring):
+                v = str(v)
+        if isinstance(v, str):
             v = _dict(((cdata_key, v),))
         cdata = None
         attrs = _dict()
@@ -441,10 +428,10 @@ def _emit(key, value, content_handler,
                 if ik == '@xmlns' and isinstance(iv, dict):
                     for k, v in iv.items():
                         attr = 'xmlns{}'.format(':{}'.format(k) if k else '')
-                        attrs[attr] = _unicode(v)
+                        attrs[attr] = str(v)
                     continue
-                if not isinstance(iv, _unicode):
-                    iv = _unicode(iv)
+                if not isinstance(iv, str):
+                    iv = str(iv)
                 attrs[ik[len(attr_prefix):]] = iv
                 continue
             children.append((ik, iv))


### PR DESCRIPTION
In Python 3, it's just `str`.