### PR TITLE
Optional force sperate dict for repetitive elements

### DIFF
--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -475,3 +475,89 @@ class XMLToDictTestCase(unittest.TestCase):
             return True
 
         parse(xml, item_depth=2, item_callback=handler)
+
+
+    def test_force_seperate_dict_basic(self):
+        xml = """
+        <servers>
+          <server>
+            <name>server1</name>
+            <os>os1</os>
+          </server>
+          <server>
+            <name>server2</name>
+            <os>os2</os>
+          </server>
+          <server>
+            <name>server3</name>
+            <os>os3</os>
+          </server>
+        </servers>
+        """
+        expectedResult = {
+            'servers': [
+                {'server':
+                    { 'name': 'server1',
+                        'os': 'os1' }
+                },
+                {'server':
+                    { 'name': 'server2',
+                        'os': 'os2' }
+                },
+                {'server':
+                    { 'name': 'server3',
+                        'os': 'os3' }
+                },
+            ],
+        }
+        self.assertEqual(parse(xml, force_seperate_dict=('server',)), expectedResult)
+
+    def test_force_seperate_dict_with_other_elements(self):
+        xml = """
+        <config>
+            <servers>
+              <not_force_seperate_element>
+                <name>server0</name>
+                <os>os0</os>
+              </not_force_seperate_element>
+              <server>
+                <name>server1</name>
+                <os>os1</os>
+              </server>
+              <not_force_seperate_element>
+                <name>server2</name>
+                <os>os2</os>
+              </not_force_seperate_element>
+              <server>
+                <name>server3</name>
+                <os>os3</os>
+              </server>
+            </servers>
+        </config>
+        """
+
+        expectedResult = {
+            'config': {
+                'servers': [
+                    {'not_force_seperate_element':
+                        { 'name': 'server0',
+                            'os': 'os0' }
+                    },
+                    {'server':
+                        { 'name': 'server1',
+                            'os': 'os1' }
+                    },
+                    { 'not_force_seperate_element':
+                        { 'name': 'server2',
+                            'os': 'os2' }
+                    },
+                    {'server':
+                        { 'name': 'server3',
+                            'os': 'os3' }
+                    }
+                ]
+            },
+        }
+
+        # only 'server' is in force_seperate_dict
+        self.assertEqual(parse(xml, force_seperate_dict=('server',)), expectedResult)


### PR DESCRIPTION
I am using xmltodict to parse the `config.xml` in Jenkins project settings.

The parameters section is with repetitive elements:
```xml
<parameterDefinitions>
        <ChoiceParameterDefinition>
          <name>ChoiceFirst</name>
          <choices>
              <string>Start</string>
              <string>Begin</string>
          </choices>
        </ChoiceParameterDefinition>
        <StringParameterDefinition>
          <name>Name</name>
          <defaultValue>foobar</defaultValue>
        </StringParameterDefinition>
        <StringParameterDefinition>
          <name>Address</name>
          <defaultValue>None</defaultValue>
        </StringParameterDefinition>
       <ChoiceParameterDefinition>
        <name>ChoiceFinal</name>
          <choices>
              <string>Final</string>
              <string>End</string>
          </choices>
       <ChoiceParameterDefinition>
      </parameterDefinitions>
```
The order of the elements in important for the Jenkins UI presentation. 
`ChoiceFirst -> Name -> Address -> ChoiceEnd`

However the original xmltodict would merge the same child elements in to a dict, and mess up the order: `ChoiceFirst -> ChoiceEnd -> Name -> Address`
```python
{ 
   parameterDefinitions: 
   {  
       ChoiceParameterDefinition: [
            {  name: "ChoiceFirst",
                choices:  {  string: ["Start", "Begin"] }  },
            {  name: "ChoiceFinal",
                choices:  {  string: ["Final", "End"] }  },
       ],
       StringParameterDefinition: [
            {  name: "Name",
                defaultValue:  "foobar"  },
            {  name: "Address",
                defaultValue:  "None"  },
       ],
   }
}
```



So I am adding a parameter `force_seperate_dict` and will allow users to force the elements of "ChoiceParameterDefinition" to become individual dict by specifying `force_seperate_dict=('ChoiceParameterDefinition')` to keep the order.


```python
{ 
   parameterDefinitions: 
   [  
       {  
           ChoiceParameterDefinition: 
            {  name: "ChoiceFirst",
                choices:  {  string: ["Start", "Begin"] }  },
        },  {
          StringParameterDefinition: 
            {  name: "Name",
                defaultValue:  "foobar"  },
       }, {
          StringParameterDefinition: 
            {  name: "Address",
                defaultValue:  "None"  },
       }, {  
           ChoiceParameterDefinition: 
           {  name: "ChoiceFinal",
                choices:  {  string: ["Final", "End"] }  },
        },
   }
}
```

Two tests are added for this and also refactor the `_should_force_list` function do avoid duplication.