### PR TITLE
feat: strip whitespace in element text content argument added

### DIFF
--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -96,6 +96,64 @@ class XMLToDictTestCase(unittest.TestCase):
             {'root': {'emptya': "           ",
                       'emptyb': {'@attr': 'attrvalue'},
                       'value': 'hello'}})
+        
+    def test_skip_whitespace_with_text(self):
+        xml = """
+        <root>
+
+
+          <emptya>      abc     </emptya>
+          <emptyb attr="attrvalue">
+
+
+          </emptyb>
+          <value>hello</value>
+        </root>
+        """
+        self.assertEqual(
+            parse(xml),
+            {'root': {'emptya': "      abc     ",
+                      'emptyb': {'@attr': 'attrvalue'},
+                      'value': 'hello'}})
+
+        
+    def test_skip_whitespace_content(self):
+        xml = """
+        <root>
+
+
+          <emptya>           </emptya>
+          <emptyb attr="attrvalue">
+
+
+          </emptyb>
+          <value>hello</value>
+        </root>
+        """
+        self.assertEqual(
+            parse(xml, strip_whitespace_content=True),
+            {'root': {'emptya': "",
+                      'emptyb': {'@attr': 'attrvalue'},
+                      'value': 'hello'}})
+        
+    def test_skip_whitespace_content_with_text(self):
+        xml = """
+        <root>
+
+
+          <emptya>     abc     </emptya>
+          <emptyb attr="attrvalue">
+
+
+          </emptyb>
+          <value>hello</value>
+        </root>
+        """
+        self.assertEqual(
+            parse(xml, strip_whitespace_content=True),
+            {'root': {'emptya': "abc",
+                      'emptyb': {'@attr': 'attrvalue'},
+                      'value': 'hello'}})
 
     def test_keep_whitespace(self):
         xml = "<root> </root>"

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -34,6 +34,7 @@ class _DictSAXHandler:
                  postprocessor=None,
                  dict_constructor=_dict,
                  strip_whitespace=True,
+                 strip_whitespace_content=False,
                  namespace_separator=':',
                  namespaces=None,
                  force_list=None,
@@ -52,6 +53,7 @@ class _DictSAXHandler:
         self.postprocessor = postprocessor
         self.dict_constructor = dict_constructor
         self.strip_whitespace = strip_whitespace
+        self.strip_whitespace_content = strip_whitespace_content
         self.namespace_separator = namespace_separator
         self.namespaces = namespaces
         self.namespace_declarations = dict_constructor()
@@ -125,6 +127,8 @@ class _DictSAXHandler:
             self.item, self.data = self.stack.pop()
             if self.strip_whitespace and data and item:
                 data = data.strip() or None
+            if self.strip_whitespace_content and data:
+                data = data.strip()
             if data and self.force_cdata and item is None:
                 item = self.dict_constructor()
             if item is not None:


### PR DESCRIPTION
This PR is related to the issue stated in https://github.com/martinblech/xmltodict/issues/361. I have found that some users do expect the whitespace within an element to be stripped. In the linked PR in the issue I found that this change was done on purpose. To make everyone happy I suggest adding another property that removes this white space from the content of the elements called `strip_whitespace_content`. Let me know what you think and if this is something that could be merged.
Based on the comments on my issue it seems that more people would like some feature of stripping the content of the elements as well.