### PR TITLE
Revert "Ensure significant whitespace is not trimmed"

### DIFF
--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -93,13 +93,13 @@ class XMLToDictTestCase(unittest.TestCase):
         """
         self.assertEqual(
             parse(xml),
-            {'root': {'emptya': "           ",
+            {'root': {'emptya': None,
                       'emptyb': {'@attr': 'attrvalue'},
                       'value': 'hello'}})
 
     def test_keep_whitespace(self):
         xml = "<root> </root>"
-        self.assertEqual(parse(xml), dict(root=' '))
+        self.assertEqual(parse(xml), dict(root=None))
         self.assertEqual(parse(xml, strip_whitespace=False),
                          dict(root=' '))
 

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -123,7 +123,7 @@ class _DictSAXHandler:
                     else self.cdata_separator.join(self.data))
             item = self.item
             self.item, self.data = self.stack.pop()
-            if self.strip_whitespace and data and item:
+            if self.strip_whitespace and data:
                 data = data.strip() or None
             if data and self.force_cdata and item is None:
                 item = self.dict_constructor()


### PR DESCRIPTION
Reverts martinblech/xmltodict#267. This is causing downstream issues (#361).