### PR TITLE
docs: clarify strip whitespace comment behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Parse XML input into a Python dictionary.
 - `cdata_separator=''`: Separator string to join multiple text nodes. This joins adjacent text nodes. For example, set to a space to avoid concatenation.
 - `postprocessor=None`: Function to modify parsed items.
 - `dict_constructor=dict`: Constructor for dictionaries (e.g., dict).
-- `strip_whitespace=True`: Remove leading/trailing whitespace in text nodes. Default is True; this trims whitespace in text nodes. Set to False to preserve whitespace exactly.
+- `strip_whitespace=True`: Remove leading/trailing whitespace in text nodes. Default is True; this trims whitespace in text nodes. Set to False to preserve whitespace exactly. When `process_comments=True`, this same flag also trims comment text; disable `strip_whitespace` if you need to preserve comment indentation or padding.
 - `namespaces=None`: Mapping of namespaces to prefixes, or None to keep full URIs.
 - `force_list=None`: Force list values for specific elements. Can be a boolean (True/False), a tuple of element names to force lists for, or a callable function that receives (path, key, value) and returns True/False. Useful for elements that may appear once or multiple times to ensure consistent list output.
 - `item_depth=0`: Depth at which to call `item_callback`.

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -329,6 +329,10 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
                     'd': '2',
                 },
             }
+        Comment text is subject to the `strip_whitespace` flag: when it is left
+        at the default `True`, comments will have leading and trailing
+        whitespace removed. Disable `strip_whitespace` to keep comment
+        indentation or padding intact.
     """
     handler = _DictSAXHandler(namespace_separator=namespace_separator,
                               **kwargs)


### PR DESCRIPTION
## Summary
- document in README that strip_whitespace also affects comment text when process_comments is enabled
- update parse() docstring to call out the shared strip_whitespace behavior for comments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca49ea61b88322a712a1bc084f3694