### PR TITLE
docs: clarify behavior for empty lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,11 @@ Convert a Python dictionary back into XML.
 - `newl='\n'`: Newline character for pretty printing.
 - `expand_iter=None`: Tag name to use for items in nested lists (breaks roundtripping).
 
+> **Note:** When building XML from dictionaries, keys whose values are empty
+> lists are skipped. For example, `{'a': []}` produces no `<a>` element. Add a
+> placeholder child (for example, `{'a': ['']}`) if an explicit empty container
+> element is required in the output.
+
 Note: xmltodict aims to cover the common 90% of cases. It does not preserve every XML nuance (attribute order, mixed content ordering, multiple top-level comments). For exact fidelity, use a full XML library such as lxml.
 
 ## Examples

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -565,6 +565,10 @@ def unparse(input_dict, output=None, encoding='utf-8', full_document=True,
     as XML node attributes, whereas keys equal to `cdata_key`
     (default=`'#text'`) are treated as character data.
 
+    Empty lists are omitted entirely: ``{"a": []}`` produces no ``<a>`` element.
+    Provide a placeholder entry (for example ``{"a": [""]}``) when an explicit
+    empty container element must be emitted.
+
     The `pretty` parameter (default=`False`) enables pretty-printing. In this
     mode, lines are terminated with `'\n'` and indented with `'\t'`, but this
     can be customized with the `newl` and `indent` parameters.


### PR DESCRIPTION
## Summary
- clarify in the README that empty lists do not generate container elements when emitting XML
- add inline documentation in `unparse` describing how to emit an explicit empty container

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ca4a2507008322875ac692a9ccdef8