### PR TITLE
refactor: remove jython-specific parsing branches

### DIFF
--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -469,11 +469,6 @@ def test_disable_entities_true_attempts_external_dtd():
     def raising_external_ref_handler(*args, **kwargs):
         parser = ParserCreate(*args, **kwargs)
         parser.ExternalEntityRefHandler = lambda *x: 0
-        try:
-            feature = "http://apache.org/xml/features/disallow-doctype-decl"
-            parser._reader.setFeature(feature, True)
-        except AttributeError:
-            pass
         return parser
     expat.ParserCreate = raising_external_ref_handler
     # Using this try/catch because a TypeError is thrown before

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -345,11 +345,7 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
         encoding,
         namespace_separator
     )
-    try:
-        parser.ordered_attributes = True
-    except AttributeError:
-        # Jython's expat does not support ordered_attributes
-        pass
+    parser.ordered_attributes = True
     parser.StartNamespaceDeclHandler = handler.startNamespaceDecl
     parser.StartElementHandler = handler.startElement
     parser.EndElementHandler = handler.endElement
@@ -358,16 +354,10 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
         parser.CommentHandler = handler.comments
     parser.buffer_text = True
     if disable_entities:
-        try:
-            # Attempt to disable DTD in Jython's expat parser (Xerces-J).
-            feature = "http://apache.org/xml/features/disallow-doctype-decl"
-            parser._reader.setFeature(feature, True)
-        except AttributeError:
-            # For CPython / expat parser.
-            # Anything not handled ends up here and entities aren't expanded.
-            parser.DefaultHandler = lambda x: None
-            # Expects an integer return; zero means failure -> expat.ExpatError.
-            parser.ExternalEntityRefHandler = lambda *x: 1
+        # Anything not handled ends up here and entities aren't expanded.
+        parser.DefaultHandler = lambda x: None
+        # Expects an integer return; zero means failure -> expat.ExpatError.
+        parser.ExternalEntityRefHandler = lambda *x: 1
     if hasattr(xml_input, 'read'):
         parser.ParseFile(xml_input)
     elif isgenerator(xml_input):


### PR DESCRIPTION
## Summary
- remove Jython-only branches around expat configuration
- drop test scaffolding that toggled Jython-specific parser features
- set ordered_attributes on the expat parser without Jython-only guards

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca4c0e774c832294ff62e852de2e5e