### PR TITLE
fix: validate XML comments

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -178,6 +178,18 @@ def test_unparse_with_multiple_top_level_comments():
     assert xml == "<!--t1--><!--t2--><a>1</a>"
 
 
+def test_unparse_rejects_comment_with_double_hyphen():
+    obj = {"#comment": "bad--comment", "a": "1"}
+    with pytest.raises(ValueError, match="cannot contain '--'"):
+        unparse(obj, full_document=True)
+
+
+def test_unparse_rejects_comment_ending_with_hyphen():
+    obj = {"#comment": "trailing-", "a": "1"}
+    with pytest.raises(ValueError, match="cannot end with '-'"):
+        unparse(obj, full_document=True)
+
+
 def test_pretty_print_with_int_indent():
     obj = {
         "a": {

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -432,6 +432,21 @@ def _validate_name(value, kind):
         raise ValueError(f"Invalid {kind} name: whitespace not allowed")
 
 
+def _validate_comment(value):
+    if isinstance(value, bytes):
+        try:
+            value = value.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("Comment text must be valid UTF-8") from exc
+    if not isinstance(value, str):
+        raise ValueError("Comment text must be a string")
+    if "--" in value:
+        raise ValueError("Comment text cannot contain '--'")
+    if value.endswith("-"):
+        raise ValueError("Comment text cannot end with '-'")
+    return value
+
+
 def _process_namespace(name, namespaces, ns_sep=':', attr_prefix='@'):
     if not isinstance(name, str):
         return name
@@ -470,7 +485,7 @@ def _emit(key, value, content_handler,
             if comment_text is None:
                 continue
             comment_text = _convert_value_to_string(comment_text)
-            if comment_text == "":
+            if not comment_text:
                 continue
             if pretty:
                 content_handler.ignorableWhitespace(depth * indent)
@@ -550,6 +565,7 @@ def _emit(key, value, content_handler,
 
 class _XMLGenerator(XMLGenerator):
     def comment(self, text):
+        text = _validate_comment(text)
         self._write(f"<!--{escape(text)}-->")
 
 


### PR DESCRIPTION
## Summary
- add validation that rejects invalid XML comment content before emission
- reuse the validation inside the custom XML generator (without double-checking) to prevent malformed output
- cover the new error paths with regression tests around comment handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca4a307c848322a3f99ca69c159bac