### PR TITLE
fix: fail closed when entities disabled

### DIFF
--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -472,6 +472,16 @@ def test_disable_entities_true_attempts_external_dtd():
     expat.ParserCreate = ParserCreate
 
 
+def test_disable_entities_allows_comments_by_default():
+    xml = """
+    <a>
+        <!-- ignored -->
+        <b>1</b>
+    </a>
+    """
+    assert parse(xml) == {'a': {'b': '1'}}
+
+
 def test_comments():
     xml = """
     <a>

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -410,7 +410,7 @@ def test_force_list_callable():
     assert parse(xml, force_list=force_list, dict_constructor=dict) == expectedResult
 
 
-def test_disable_entities_true_ignores_xmlbomb():
+def test_disable_entities_true_rejects_xmlbomb():
     xml = """
     <!DOCTYPE xmlbomb [
         <!ENTITY a "1234567890" >
@@ -419,13 +419,8 @@ def test_disable_entities_true_ignores_xmlbomb():
     ]>
     <bomb>&c;</bomb>
     """
-    expectedResult = {'bomb': None}
-    try:
-        parse_attempt = parse(xml, disable_entities=True)
-    except expat.ExpatError:
-        assert True
-    else:
-        assert parse_attempt == expectedResult
+    with pytest.raises(expat.ExpatError, match="entities are disabled"):
+        parse(xml, disable_entities=True)
 
 
 def test_disable_entities_false_returns_xmlbomb():
@@ -442,20 +437,15 @@ def test_disable_entities_false_returns_xmlbomb():
     assert parse(xml, disable_entities=False) == expectedResult
 
 
-def test_disable_entities_true_ignores_external_dtd():
+def test_disable_entities_true_rejects_external_dtd():
     xml = """
     <!DOCTYPE external [
         <!ENTITY ee SYSTEM "http://www.python.org/">
     ]>
     <root>&ee;</root>
     """
-    expectedResult = {'root': None}
-    try:
-        parse_attempt = parse(xml, disable_entities=True)
-    except expat.ExpatError:
-        assert True
-    else:
-        assert parse_attempt == expectedResult
+    with pytest.raises(expat.ExpatError, match="entities are disabled"):
+        parse(xml, disable_entities=True)
 
 
 def test_disable_entities_true_attempts_external_dtd():

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -361,6 +361,8 @@ def parse(xml_input, encoding=None, expat=expat, process_namespaces=False,
             if not text:
                 return
             stripped = text.lstrip()
+            if stripped.startswith('<!--'):
+                return
             if stripped.startswith('<!') or stripped.startswith('&'):
                 _forbid_entities()
 


### PR DESCRIPTION
## Summary
- raise `ExpatError` when entity-related callbacks fire while entities are disabled
- update entity security tests to assert the parser now fails closed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca50118464832284d6c5b460d14f9e