### PR TITLE
fix: grant release workflow upload permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
## Summary
- update the publish workflow permissions to allow writing release assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca5488887883228c99c66bc93409ce