### PR TITLE
fix(unparse): serialize boolean attributes as lowercase text

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -307,6 +307,14 @@ def test_boolean_unparse():
     xml = unparse(dict(x=False))
     assert xml == expected_xml
 
+    expected_xml = '<?xml version="1.0" encoding="utf-8"?>\n<x attr="true"></x>'
+    xml = unparse({'x': {'@attr': True}})
+    assert xml == expected_xml
+
+    expected_xml = '<?xml version="1.0" encoding="utf-8"?>\n<x attr="false"></x>'
+    xml = unparse({'x': {'@attr': False}})
+    assert xml == expected_xml
+
 
 def test_rejects_tag_name_with_angle_brackets():
     # Minimal guard: disallow '<' or '>' to prevent breaking tag context

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -510,7 +510,7 @@ def _emit(key, value, content_handler,
                 if iv is None:
                     iv = ''
                 elif not isinstance(iv, str):
-                    iv = str(iv)
+                    iv = _convert_value_to_string(iv)
                 attr_name = ik[len(attr_prefix) :]
                 _validate_name(attr_name, "attribute")
                 attrs[attr_name] = iv


### PR DESCRIPTION
## Description
This PR fixes a bug where boolean values in attributes were serialized as Python strings (`"True"`/`"False"`) instead of valid XML booleans (`"true"`/`"false"`).

## Changes
* Updated `_emit` in `xmltodict.py` to use `_convert_value_to_string` for attribute values.
* Added regression tests in `tests/test_dicttoxml.py` to verify that both element text and attributes correctly serialize booleans to lowercase.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] Tests added/updated
- [x] All tests passed locally