### PR TITLE
fix(unparse): fix TypeError with bytes attributes

### DIFF
--- a/xmltodict.py
+++ b/xmltodict.py
@@ -374,7 +374,7 @@ def _convert_value_to_string(value):
 
     Handles boolean values consistently by converting them to lowercase.
     """
-    if isinstance(value, (str, bytes)):
+    if isinstance(value, str):
         return value
     if isinstance(value, bool):
         return "true" if value else "false"


### PR DESCRIPTION
This removes 'bytes' from the type check in _convert_value_to_string, allowing bytes objects to fall through to str() conversion. This restores the behavior of converting bytes to their string representation (e.g. "b'value'") preventing a crash in XMLGenerator.