### PR TITLE
fix(unparse): correctly serialize bool and bytes values in attributes…

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -307,6 +307,14 @@ def test_boolean_unparse():
     xml = unparse(dict(x=False))
     assert xml == expected_xml
 
+    expected_xml = '<?xml version="1.0" encoding="utf-8"?>\n<x attr="true"></x>'
+    xml = unparse({'x': {'@attr': True}})
+    assert xml == expected_xml
+
+    expected_xml = '<?xml version="1.0" encoding="utf-8"?>\n<x attr="false"></x>'
+    xml = unparse({'x': {'@attr': False}})
+    assert xml == expected_xml
+
 
 def test_rejects_tag_name_with_angle_brackets():
     # Minimal guard: disallow '<' or '>' to prevent breaking tag context
@@ -604,3 +612,20 @@ def test_none_text_with_short_empty_elements_and_attributes():
 
 def test_none_attribute_serializes_as_empty_string():
     assert unparse({"x": {"@pro": None}}, full_document=False) == '<x pro=""></x>'
+
+def test_bytes_text_node():
+    assert _strip(unparse({'a': b'hello'})) == '<a>hello</a>'
+
+
+def test_bytes_attribute():
+    assert _strip(unparse({'a': {'@attr': b'hello'}})) == '<a attr="hello"></a>'
+
+
+def test_bytes_text_node_invalid_utf8():
+    with pytest.raises(ValueError, match="must be valid UTF-8"):
+        unparse({'a': b'\xff'})
+
+
+def test_bytes_attribute_invalid_utf8():
+    with pytest.raises(ValueError, match="must be valid UTF-8"):
+        unparse({'a': {'@attr': b'\xff'}})


### PR DESCRIPTION
Fixes three related bugs in `unparse` around non-`str` scalar serialization.
1. **Boolean attributes** serialized as `"True"`/`"False"` (Python's default `str()`) rather than `"true"`/`"false"`, inconsistent with how boolean element text was already handled.
2. **bytes attributes** caused a `TypeError` inside `XMLGenerator.startElement` because `_convert_value_to_string` returned `bytes` unchanged and `quoteattr()` expects `str`.
3. **bytes text nodes** were silently iterated as a sequence of integers (since `bytes` is iterable), causing a spurious `ValueError: document with multiple roots` instead of being treated as a single value.

**Changes**
- `_convert_value_to_string` now explicitly handles each type in priority order: `str` (passthrough), `bytes` (UTF-8 decode, raising `ValueError` on failure), `bool` (lowercase), everything else (`str()`). The function now always returns `str`.
- `_emit` adds `bytes` to the `isinstance` guard that wraps non-iterable values in a list, preventing bytes from being iterated.
- Attribute serialization uses `_convert_value_to_string` instead of bare `str()`, bringing it in line with the text node path.

**Tests added**
- `test_boolean_unparse` extended to cover boolean attributes
- `test_bytes_text_node` — bytes text node decodes correctly
- `test_bytes_attribute` — bytes attribute decodes correctly
- `test_bytes_text_node_invalid_utf8` — invalid UTF-8 bytes raises `ValueError`
- `test_bytes_attribute_invalid_utf8` — invalid UTF-8 bytes raises `ValueError`