### PR TITLE
fix(unparse): correctly serialize bool and bytes

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -307,6 +307,14 @@ def test_boolean_unparse():
     xml = unparse(dict(x=False))
     assert xml == expected_xml
 
+    expected_xml = '<?xml version="1.0" encoding="utf-8"?>\n<x attr="true"></x>'
+    xml = unparse({'x': {'@attr': True}})
+    assert xml == expected_xml
+
+    expected_xml = '<?xml version="1.0" encoding="utf-8"?>\n<x attr="false"></x>'
+    xml = unparse({'x': {'@attr': False}})
+    assert xml == expected_xml
+
 
 def test_rejects_tag_name_with_angle_brackets():
     # Minimal guard: disallow '<' or '>' to prevent breaking tag context
@@ -604,3 +612,23 @@ def test_none_text_with_short_empty_elements_and_attributes():
 
 def test_none_attribute_serializes_as_empty_string():
     assert unparse({"x": {"@pro": None}}, full_document=False) == '<x pro=""></x>'
+
+def test_bytes_text_node():
+    assert _strip(unparse({'a': b'hello'})) == '<a>hello</a>'
+
+
+def test_bytes_attribute():
+    assert _strip(unparse({'a': {'@attr': b'hello'}})) == '<a attr="hello"></a>'
+
+
+def test_bytes_text_node_invalid_utf8():
+    with pytest.raises(ValueError, match="must be valid UTF-8"):
+        unparse({'a': b'\xff'})
+
+
+def test_bytes_attribute_invalid_utf8():
+    with pytest.raises(ValueError, match="must be valid UTF-8"):
+        unparse({'a': {'@attr': b'\xff'}})
+
+def test_bytes_text_node_with_expand_iter():
+    assert _strip(unparse({'a': b'hello'}, expand_iter='item')) == '<a>hello</a>'

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -374,8 +374,13 @@ def _convert_value_to_string(value):
 
     Handles boolean values consistently by converting them to lowercase.
     """
-    if isinstance(value, (str, bytes)):
+    if isinstance(value, str):
         return value
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError as exc:
+            raise ValueError("bytes value must be valid UTF-8") from exc
     if isinstance(value, bool):
         return "true" if value else "false"
     return str(value)
@@ -474,7 +479,7 @@ def _emit(key, value, content_handler,
         key, value = result
     # Minimal validation to avoid breaking out of tag context
     _validate_name(key, "element")
-    if not hasattr(value, '__iter__') or isinstance(value, (str, dict)):
+    if not hasattr(value, '__iter__') or isinstance(value, (str, bytes, dict)):
         value = [value]
     for index, v in enumerate(value):
         if full_document and depth == 0 and index > 0:
@@ -482,7 +487,7 @@ def _emit(key, value, content_handler,
         if v is None:
             v = {}
         elif not isinstance(v, (dict, str)):
-            if expand_iter and hasattr(v, '__iter__'):
+            if expand_iter and hasattr(v, '__iter__') and not isinstance(v, bytes):
                 v = {expand_iter: v}
             else:
                 v = _convert_value_to_string(v)
@@ -510,7 +515,7 @@ def _emit(key, value, content_handler,
                 if iv is None:
                     iv = ''
                 elif not isinstance(iv, str):
-                    iv = str(iv)
+                    iv = _convert_value_to_string(iv)
                 attr_name = ik[len(attr_prefix) :]
                 _validate_name(attr_name, "attribute")
                 attrs[attr_name] = iv


### PR DESCRIPTION
Fixes four related bugs in `unparse` around non-`str` scalar serialization.

**Problems**
1. **Boolean attributes** serialized as `"True"`/`"False"` (Python's default `str()`) rather than `"true"`/`"false"`, inconsistent with how boolean element text was already handled.
2. **bytes attributes** caused a `TypeError` inside `XMLGenerator.startElement` because `_convert_value_to_string` returned `bytes` unchanged and `quoteattr()` expects `str`.
3. **bytes text nodes** were silently iterated as a sequence of integers (since `bytes` is iterable), causing a spurious `ValueError: document with multiple roots` instead of being treated as a single value.
4. **bytes text nodes with `expand_iter`** caused infinite recursion: after being wrapped into a single-item list, each loop iteration saw `bytes` as iterable and the `expand_iter` branch repeatedly re-wrapped it into `{expand_iter: v}`, calling `_emit` forever.

**Changes**
- `_convert_value_to_string` now explicitly handles each type in priority order: `str` (passthrough), `bytes` (UTF-8 decode, raising `ValueError` on failure), `bool` (lowercase), everything else (`str()`). The function now always returns `str`.
- `_emit` adds `bytes` to the `isinstance` guard that wraps non-iterable values in a list, preventing bytes from being iterated as a sequence of roots.
- `_emit` excludes `bytes` from the `expand_iter` branch, routing it to `_convert_value_to_string` instead.
- Attribute serialization uses `_convert_value_to_string` instead of bare `str()`, bringing it in line with the text node path.

**Tests added**
- `test_boolean_unparse` extended to cover boolean attributes
- `test_bytes_text_node` — bytes text node decodes correctly
- `test_bytes_attribute` — bytes attribute decodes correctly
- `test_bytes_text_node_invalid_utf8` — invalid UTF-8 bytes raises `ValueError`
- `test_bytes_attribute_invalid_utf8` — invalid UTF-8 bytes raises `ValueError`
- `test_bytes_text_node_with_expand_iter` — bytes text node decodes correctly when `expand_iter` is set