### PR TITLE
Fix: Reject null bytes in XML element/attribute names

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -15,6 +15,13 @@ def test_root():
     assert obj == parse(unparse(obj))
     assert unparse(obj) == unparse(parse(unparse(obj)))
 
+def test_null_byte_rejection():
+    """Null bytes in element names should be rejected."""
+    with pytest.raises(ValueError):
+        unparse({"root": {"a\x00b": "value"}})
+    
+    with pytest.raises(ValueError):
+        unparse({"root": {"@a\x00b": "value"}})
 
 def test_simple_cdata():
     obj = {'a': 'b'}

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -393,6 +393,8 @@ def _validate_name(value, kind):
     """
     if not isinstance(value, str):
         raise ValueError(f"{kind} name must be a string")
+    if '\x00' in value:
+        raise ValueError(f'Invalid {kind} name: null bytes not allowed')
     if value.startswith("?") or value.startswith("!"):
         raise ValueError(f'Invalid {kind} name: cannot start with "?" or "!"')
     if "<" in value or ">" in value:


### PR DESCRIPTION
## Summary
Prevents generation of malformed XML by rejecting null bytes in element 
and attribute names during unparsing.

## Changes
- Added null byte validation in `_validate_name()` function
- Added test cases for null byte rejection in elements and attributes

## Testing
- All existing tests pass
- New tests verify null byte rejection in element and attribute names

## Motivation
Null bytes (\x00) are invalid in XML names per XML 1.0 specification 
and cause malformed XML that cannot be parsed.