### PR TITLE
reject '&' in element and attribute names

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -536,6 +536,18 @@ def test_rejects_names_with_quotes_and_equals():
             unparse({"a": {"@xmlns": {prefix: "http://e/"}}}, full_document=False)
 
 
+def test_rejects_names_with_ampersand():
+    # Element names
+    with pytest.raises(ValueError):
+        unparse({"a&b": "x"}, full_document=False)
+    # Attribute names
+    with pytest.raises(ValueError):
+        unparse({"a": {"@a&b": "x"}}, full_document=False)
+    # xmlns prefixes
+    with pytest.raises(ValueError):
+        unparse({"a": {"@xmlns": {"a&b": "http://e/"}}}, full_document=False)
+
+
 def test_pretty_print_and_short_empty_elements_consistency():
     """Test that pretty and compact modes produce equivalent results when stripped.
 

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -397,6 +397,8 @@ def _validate_name(value, kind):
         raise ValueError(f'Invalid {kind} name: cannot start with "?" or "!"')
     if "<" in value or ">" in value:
         raise ValueError(f'Invalid {kind} name: "<" or ">" not allowed')
+    if "&" in value:
+        raise ValueError(f'Invalid {kind} name: "&" not allowed')
     if "/" in value:
         raise ValueError(f'Invalid {kind} name: "/" not allowed')
     if '"' in value or "'" in value:


### PR DESCRIPTION
`_validate_name` already rejects the other XML metacharacters in names (`<`, `>` and both quotes) so untrusted keys can't produce unsafe names, but `&` slips through and gets emitted as a raw entity-reference start in tag or attribute name position, so the output stops being well-formed. Reject it there too; an ampersand can't be escaped inside a name. Covers element names, attribute names and xmlns prefixes, which all run through this one validator.