### PR TITLE
reject empty element and attribute names in unparse

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -521,6 +521,19 @@ def test_rejects_xmlns_prefix_with_slash_or_whitespace():
         unparse({"a": {"@xmlns": {"bad prefix": "http://e/"}}}, full_document=False)
 
 
+def test_rejects_empty_element_and_attribute_names():
+    # Empty element name would emit "<>...</>", non-well-formed XML
+    with pytest.raises(ValueError):
+        unparse({"": "x"}, full_document=False)
+    # Bare attr_prefix yields an empty attribute name, emitting "<a =...>"
+    with pytest.raises(ValueError):
+        unparse({"a": {"@": "x"}}, full_document=False)
+    # The empty default-namespace prefix stays valid (xmlns="...")
+    assert unparse(
+        {"a": {"@xmlns": {"": "http://e/"}}}, full_document=False
+    ) == '<a xmlns="http://e/"></a>'
+
+
 def test_rejects_names_with_quotes_and_equals():
     # Element names
     for name in ['a"b', "a'b", "a=b"]:

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -393,6 +393,8 @@ def _validate_name(value, kind):
     """
     if not isinstance(value, str):
         raise ValueError(f"{kind} name must be a string")
+    if value == "":
+        raise ValueError(f"{kind} name must not be empty")
     if value.startswith("?") or value.startswith("!"):
         raise ValueError(f'Invalid {kind} name: cannot start with "?" or "!"')
     if "<" in value or ">" in value:
@@ -510,7 +512,8 @@ def _emit(key, value, content_handler,
                                         attr_prefix)
                 if ik == '@xmlns' and isinstance(iv, dict):
                     for k, v in iv.items():
-                        _validate_name(k, "attribute")
+                        if k:
+                            _validate_name(k, "attribute")
                         attr = 'xmlns{}'.format(f':{k}' if k else '')
                         attrs[attr] = '' if v is None else _convert_value_to_string(
                             v, encoding=encoding, bytes_errors=bytes_errors


### PR DESCRIPTION
_validate_name screens out the XML metacharacters but lets the empty string through, so a dict key of "" emits a bare <></> and a key equal to attr_prefix emits <a ="x">, neither of which is well-formed. Reject empty names in the validator. The one legitimately empty case is the default-namespace prefix under @xmlns, so the xmlns branch in _emit only validates a non-empty prefix and still emits xmlns="...".