### PR TITLE
test: pin uncovered comment and force_list branches (coverage 95.86% to 97.63%)

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -710,3 +710,42 @@ def test_none_text_with_short_empty_elements_and_attributes():
 
 def test_none_attribute_serializes_as_empty_string():
     assert unparse({"x": {"@pro": None}}, full_document=False) == '<x pro=""></x>'
+
+
+def test_unparse_skips_none_comment():
+    obj = {"a": {"#comment": None, "b": "1"}}
+    xml = _strip(unparse(obj, full_document=True))
+    assert xml == "<a><b>1</b></a>"
+
+
+def test_unparse_skips_empty_comment():
+    obj = {"a": {"#comment": "", "b": "1"}}
+    xml = _strip(unparse(obj, full_document=True))
+    assert xml == "<a><b>1</b></a>"
+
+
+def test_unparse_filters_none_and_empty_comments_in_list():
+    obj = {"a": {"#comment": ["n1", None, "", "n2"], "b": "1"}}
+    xml = _strip(unparse(obj, full_document=True))
+    assert xml == "<a><!--n1--><!--n2--><b>1</b></a>"
+
+
+def test_pretty_print_element_comments():
+    obj = {"a": {"#comment": ["n1", "n2"], "b": "1"}}
+    xml = dedent('''\
+    <?xml version="1.0" encoding="utf-8"?>
+    <a>
+    \t<!--n1-->
+    \t<!--n2-->
+    \t<b>1</b>
+    </a>''')
+    assert xml == unparse(obj, pretty=True)
+
+
+def test_pretty_print_top_level_comment_with_int_indent():
+    obj = {"#comment": "top", "a": "1"}
+    xml = dedent('''\
+    <?xml version="1.0" encoding="utf-8"?>
+    <!--top-->
+    <a>1</a>''')
+    assert xml == unparse(obj, pretty=True, indent=4)

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -627,3 +627,9 @@ def test_namespace_on_root_without_other_attrs():
         }
     }
     assert parse(xml, process_namespaces=True, namespaces=namespaces) == expected
+
+
+def test_force_list_true_applies_to_all_keys():
+    xml = "<a><b>1</b><b>2</b><c>x</c></a>"
+    expected = {"a": [{"b": ["1", "2"], "c": ["x"]}]}
+    assert parse(xml, force_list=True) == expected


### PR DESCRIPTION
This PR adds 6 behavior-pinning tests for public-API branches that were not
exercised by the existing suite. No production code is changed. Every expected
value was taken from observed output of the current implementation, so these
tests pin today's behavior against accidental regression.

### What each test pins

`tests/test_xmltodict.py`
- `test_force_list_true_applies_to_all_keys` — `parse(xml, force_list=True)` wraps every element value in a list (the boolean branch of `_should_force_list`).

`tests/test_dicttoxml.py`
- `test_unparse_skips_none_comment` — a `None` `#comment` value emits no comment node.
- `test_unparse_skips_empty_comment` — an empty-string comment is skipped.
- `test_unparse_filters_none_and_empty_comments_in_list` — `None`/`""` entries inside a comment list are filtered, valid entries still emitted.
- `test_pretty_print_element_comments` — pretty-printing indents comments and terminates them with `newl`.
- `test_pretty_print_top_level_comment_with_int_indent` — an integer `indent` is converted to spaces in the comment emit path for top-level comments, matching the element-path behavior.

### Coverage

| | Statements | Missed | Coverage |
|---|---|---|---|
| Before | 338 | 14 | 95.86% |
| After | 338 | 8 | 97.63% |

Test results: **125 passed** (119 existing + 6 new), 0 failed. (Python 3.14.2, win32)

### Remaining uncovered lines (intentionally not tested)

Lines 71, 123–124, 412–415, 417 are defensive branches that appear unreachable
through the public `parse`/`unparse` API (verified empirically):
- 71: `_attrs_to_dict` dict passthrough — `parse()` always sets `ordered_attributes=True`, so expat delivers attribute lists.
- 123–124: streaming `endElement` with an empty stack — `startElement` always pushes at `len(path) >= item_depth` first.
- 412–415, 417: `_validate_comment` bytes/non-str branches — `_emit` converts values to `str` before `comment()` is called.

Testing them would require reaching into private internals, so they were left
uncovered rather than padded. Happy to add such tests if you prefer, or they
could be candidates for `# pragma: no cover`.
