### PR TITLE
fix: preserve attribute local name when namespace prefix is empty

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -321,6 +321,37 @@ xmlns:b="http://b.com/"><x a:attr="val">1</x><a:y>2</a:y><b:z>3</b:z></root>'''
     assert xml == expected_xml
 
 
+def test_namespaced_attribute_with_empty_prefix_keeps_local_name():
+    # Mapping an attribute namespace to the empty prefix strips the namespace;
+    # default namespaces do not apply to attributes. The local attribute name
+    # must still be emitted intact, without dropping its first character.
+    obj = {
+        'root': {
+            '@xmlns': {'': 'urn:d'},
+            '@urn:d:myattr': 'val',
+            '#text': 'x',
+        },
+    }
+    xml = unparse(obj, namespaces={'urn:d': ''}, full_document=False)
+    assert xml == '<root xmlns="urn:d" myattr="val">x</root>'
+
+
+def test_unmapped_namespaced_attribute_keeps_local_name():
+    # An unmapped attribute namespace is stripped, not moved into a default
+    # namespace; the local attribute name must still be preserved.
+    obj = {'root': {'@urn:d:myattr': 'val', '#text': 'x'}}
+    xml = unparse(obj, namespaces={'urn:other': 'o'}, full_document=False)
+    assert xml == '<root myattr="val">x</root>'
+
+
+def test_namespaced_attribute_with_custom_attr_prefix_keeps_local_name():
+    obj = {'root': {'!urn:d:myattr': 'val', '#text': 'x'}}
+    xml = unparse(
+        obj, namespaces={'urn:d': ''}, attr_prefix='!', full_document=False
+    )
+    assert xml == '<root myattr="val">x</root>'
+
+
 def test_xmlns_values_use_consistent_boolean_coercion():
     xml = unparse({"root": {"@xmlns": {"a": True}}}, full_document=False)
     assert xml == '<root xmlns:a="true"></root>'

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -520,7 +520,13 @@ def _emit(key, value, content_handler,
                     iv = ''
                 elif not isinstance(iv, str):
                     iv = _convert_value_to_string(iv, encoding=encoding, bytes_errors=bytes_errors)
-                attr_name = ik[len(attr_prefix) :]
+                # `_process_namespace` may have already consumed the attribute
+                # prefix when the attribute namespace resolves to an empty
+                # prefix or is unmapped; keep the local name intact.
+                if ik.startswith(attr_prefix):
+                    attr_name = ik[len(attr_prefix) :]
+                else:
+                    attr_name = ik
                 _validate_name(attr_name, "attribute")
                 attrs[attr_name] = iv
                 continue


### PR DESCRIPTION
### Problem

`unparse(..., namespaces=<map>)` silently drops the first character of an attribute's local name when that attribute is namespaced and its namespace resolves to an empty attribute prefix or is not present in the namespace map.

```python
import xmltodict
p = xmltodict.parse('<root xmlns:d="urn:d" d:myattr="val">x</root>', process_namespaces=True)
# {'root': {'@urn:d:myattr': 'val', '@xmlns': {'d': 'urn:d'}, '#text': 'x'}}
xmltodict.unparse(p, namespaces={'urn:d': ''}, full_document=False)
# '<root xmlns="urn:d" yattr="val">x</root>'   <-- 'myattr' corrupted to 'yattr'
```

This strips the attribute namespace on output, but the local attribute name must remain intact; default namespaces do not apply to attributes.

### Cause

In `_emit`, `_process_namespace(ik, ...)` returns the attribute key with its namespace resolved. When the resolved prefix is non-empty it keeps the leading `@` (e.g. `@x:myattr`), but when the attribute namespace resolves to the empty prefix or is unmapped it returns the bare local name (`myattr`) with the `@` already consumed. The next line then unconditionally did `attr_name = ik[len(attr_prefix):]`, assuming the `@` was still there, so it removed a real name character.

### Fix

Only strip the prefix when it is still present:

```python
if ik.startswith(attr_prefix):
    attr_name = ik[len(attr_prefix):]
else:
    attr_name = ik
```

Normal prefixed attributes and plain non-namespaced attributes are unchanged because `ik` still starts with the active `attr_prefix` there; only the stripped/unmapped namespace path, which previously corrupted the local name, is corrected.

### Tests

Added `test_namespaced_attribute_with_empty_prefix_keeps_local_name`, `test_unmapped_namespaced_attribute_keeps_local_name`, and `test_namespaced_attribute_with_custom_attr_prefix_keeps_local_name` to `tests/test_dicttoxml.py`, next to `test_namespace_support`. The first two fail before the fix (name loses its first character) and pass after; the third pins the same regression with a custom `attr_prefix`. Full suite: 128 passed.

I used an AI assistant to help investigate this under my direction, and I have reviewed and verified the change myself.
