### PR TITLE
fix: reject empty element and attribute names in unparse

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -501,6 +501,16 @@ def test_rejects_tag_name_with_whitespace():
             unparse({name: "x"}, full_document=False)
 
 
+def test_rejects_empty_element_name():
+    with pytest.raises(ValueError):
+        unparse({"": "x"}, full_document=False)
+
+
+def test_rejects_empty_attribute_name():
+    with pytest.raises(ValueError):
+        unparse({"a": {"@": "x"}}, full_document=False)
+
+
 def test_rejects_attribute_name_with_slash():
     with pytest.raises(ValueError):
         unparse({"a": {"@bad/name": "x"}}, full_document=False)

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -393,6 +393,8 @@ def _validate_name(value, kind):
     """
     if not isinstance(value, str):
         raise ValueError(f"{kind} name must be a string")
+    if kind == 'element' and not value:
+        raise ValueError(f"{kind} name must not be empty")
     if value.startswith("?") or value.startswith("!"):
         raise ValueError(f'Invalid {kind} name: cannot start with "?" or "!"')
     if "<" in value or ">" in value:
@@ -521,6 +523,8 @@ def _emit(key, value, content_handler,
                 elif not isinstance(iv, str):
                     iv = _convert_value_to_string(iv, encoding=encoding, bytes_errors=bytes_errors)
                 attr_name = ik[len(attr_prefix) :]
+                if not attr_name:
+                    raise ValueError("attribute name must not be empty")
                 _validate_name(attr_name, "attribute")
                 attrs[attr_name] = iv
                 continue


### PR DESCRIPTION
_validate_name did not check for empty strings, allowing unparse to produce invalid XML.

Steps to reproduce:

    import xmltodict
    xmltodict.unparse({"": "value"})
    # Output: <?xml version="1.0" encoding="utf-8"?>
    # <>value</>
    # This is invalid XML that cannot be re-parsed.

    xmltodict.unparse({"a": {"@": "x"}})
    # Output: <?xml version="1.0" encoding="utf-8"?>
    # <a ="x"></a>
    # The attribute name is empty, producing malformed XML.

Root cause: _validate_name allows empty strings for both element and
attribute names. The XML spec requires non-empty names.

Fix: Add an empty-string guard for element names in _validate_name
(kind=element), and for attribute names at the call site in _emit
after stripping the attr_prefix. The existing default namespace
support (empty prefix in @xmlns) is preserved.