### PR TITLE
fix(streaming): preserve #text on streamed items

### DIFF
--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -201,6 +201,18 @@ def test_streaming_text_with_attrs():
     assert _stream(xml, 2) == [{'@id': '1', '#text': 'hello'}]
 
 
+def test_streaming_text_postprocessor():
+    def postprocessor(path, key, value):
+        if key == '#text':
+            assert path == [('items', None), ('item', {'id': '1'})]
+            return 'text', value.upper()
+        return key, value
+
+    xml = '<items><item id="1">hello</item></items>'
+    assert _stream(xml, 2, postprocessor=postprocessor) == \
+        [{'@id': '1', 'text': 'HELLO'}]
+
+
 def test_streaming_text_with_children():
     xml = '<a>free text<b>1</b><b>2</b></a>'
     assert _stream(xml, 1) == [{'b': ['1', '2'], '#text': 'free text'}]

--- a/tests/test_xmltodict.py
+++ b/tests/test_xmltodict.py
@@ -187,6 +187,81 @@ def test_streaming_returns_none():
     assert result is None
 
 
+def _stream(xml, depth, **kwargs):
+    items = []
+    parse(xml, item_depth=depth,
+          item_callback=lambda path, item: items.append(item) or True,
+          **kwargs)
+    return items
+
+
+def test_streaming_text_with_attrs():
+    # char data was dropped when the streamed item had attributes (#257)
+    xml = '<items><item id="1">hello</item></items>'
+    assert _stream(xml, 2) == [{'@id': '1', '#text': 'hello'}]
+
+
+def test_streaming_text_with_children():
+    xml = '<a>free text<b>1</b><b>2</b></a>'
+    assert _stream(xml, 1) == [{'b': ['1', '2'], '#text': 'free text'}]
+    xml = '<items><item><sub>x</sub>tail</item></items>'
+    assert _stream(xml, 2) == [{'sub': 'x', '#text': 'tail'}]
+
+
+def test_streaming_text_whitespace():
+    xml = '<items><item id="1"> spaced </item></items>'
+    assert _stream(xml, 2) == [{'@id': '1', '#text': 'spaced'}]
+    assert _stream(xml, 2, strip_whitespace=False) == \
+        [{'@id': '1', '#text': ' spaced '}]
+    # whitespace-only text is stripped to nothing, like non-streaming parse
+    xml = '<items><item id="1"> </item></items>'
+    assert _stream(xml, 2) == [{'@id': '1'}]
+
+
+def test_streaming_force_cdata_and_cdata_key():
+    xml = '<items><item>x</item></items>'
+    assert _stream(xml, 2, force_cdata=True) == [{'#text': 'x'}]
+    xml = '<items><item id="1">x</item></items>'
+    assert _stream(xml, 2, cdata_key='$') == [{'@id': '1', '$': 'x'}]
+
+
+def test_streaming_matches_nonstreaming():
+    docs = [
+        '<r><item>plain</item></r>',
+        '<r><item id="1">text</item><item>only</item></r>',
+        '<r><item a="1"><c>x</c>tail</item><item a="2">lead<c>y</c></item></r>',
+        '<r><item><sub><deep d="3">v</deep></sub>mixed</item></r>',
+        '<r><item> </item><item id="1"> </item></r>',
+    ]
+    for xml in docs:
+        expected = parse(xml)['r']['item']
+        if not isinstance(expected, list):
+            expected = [expected]
+        assert _stream(xml, 2) == expected, xml
+
+
+def test_streaming_random_docs_match_nonstreaming():
+    import random
+    rnd = random.Random(20260715)
+    for _ in range(200):
+        items = []
+        for i in range(rnd.randint(1, 4)):
+            attr = f' id="{i}"' if rnd.random() < 0.5 else ''
+            children = ''.join(f'<c{j}>v{j}</c{j}>'
+                               for j in range(rnd.randint(0, 2)))
+            text = rnd.choice(['', ' ', 'txt', 'a b'])
+            if rnd.random() < 0.5:
+                body = text + children
+            else:
+                body = children + text
+            items.append(f'<item{attr}>{body}</item>')
+        xml = f"<r>{''.join(items)}</r>"
+        expected = parse(xml)['r']['item']
+        if not isinstance(expected, list):
+            expected = [expected]
+        assert _stream(xml, 2) == expected, xml
+
+
 def test_postprocessor():
     def postprocessor(path, key, value):
         try:

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -107,10 +107,18 @@ class _DictSAXHandler:
         # without attaching it back to its parent. This avoids accumulating all
         # streamed items in memory when using item_depth > 0.
         if len(self.path) == self.item_depth:
+            data = (None if not self.data
+                    else self.cdata_separator.join(self.data))
             item = self.item
-            if item is None:
-                item = (None if not self.data
-                        else self.cdata_separator.join(self.data))
+            if self.strip_whitespace and data:
+                data = data.strip() or None
+            if data and self._should_force_cdata(name, data) and item is None:
+                item = self.dict_constructor()
+            if item is not None:
+                if data:
+                    self.push_data(item, self.cdata_key, data)
+            else:
+                item = data
 
             should_continue = self.item_callback(self.path, item)
             if not should_continue:


### PR DESCRIPTION
In streaming mode (`item_depth` + `item_callback`), an element's character data is silently dropped when the item has attributes or child elements, and text-only items bypass `strip_whitespace`/`force_cdata`. This is the behavior asked about in #257.

Repro: `parse('<items><item id="1">hello</item></items>', item_depth=2, item_callback=cb)` hands the callback `{'@id': '1'}`, while the non-streaming parse of the same document yields `{'@id': '1', '#text': 'hello'}`.

The fix builds the streamed item the same way `endElement` already does on the non-streaming path: join the char data, apply `strip_whitespace`, honor `force_cdata`, and add it under `cdata_key` when the item holds attributes/children. Tests cover attr+text, child+text, whitespace handling, `force_cdata`/`cdata_key`, and verify streamed items match the non-streaming parse on fixed and seeded randomized documents.
