### PR TITLE
fix(unparse): honor custom attr_prefix for xmlns declaration dicts

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -338,6 +338,23 @@ def test_xmlns_dict_honors_custom_attr_prefix():
     assert xml == '<root xmlns:a="http://a.com/" id="7"></root>'
 
 
+def test_namespace_roundtrip_honors_custom_attr_prefix():
+    obj = parse(
+        '<root xmlns:a="http://a.com/" id="7"><a:y>2</a:y></root>',
+        process_namespaces=True,
+        attr_prefix="!",
+    )
+
+    xml = unparse(
+        obj,
+        attr_prefix="!",
+        namespaces={"http://a.com/": "a"},
+        full_document=False,
+    )
+
+    assert xml == '<root id="7" xmlns:a="http://a.com/"><a:y>2</a:y></root>'
+
+
 def test_xmlns_values_decode_bytes_with_output_encoding():
     xml = unparse(
         {"root": {"@xmlns": {"a": b"http://ex\xe9.com/"}}},

--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -326,6 +326,18 @@ def test_xmlns_values_use_consistent_boolean_coercion():
     assert xml == '<root xmlns:a="true"></root>'
 
 
+def test_xmlns_dict_honors_custom_attr_prefix():
+    # A namespace-declaration dict must be recognized under a custom
+    # attr_prefix, like every other attribute — otherwise unparse cannot
+    # round-trip what parse(..., attr_prefix="!") produced.
+    xml = unparse(
+        {"root": {"!xmlns": {"a": "http://a.com/"}, "!id": "7"}},
+        attr_prefix="!",
+        full_document=False,
+    )
+    assert xml == '<root xmlns:a="http://a.com/" id="7"></root>'
+
+
 def test_xmlns_values_decode_bytes_with_output_encoding():
     xml = unparse(
         {"root": {"@xmlns": {"a": b"http://ex\xe9.com/"}}},

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -508,7 +508,7 @@ def _emit(key, value, content_handler,
             if isinstance(ik, str) and ik.startswith(attr_prefix):
                 ik = _process_namespace(ik, namespaces, namespace_separator,
                                         attr_prefix)
-                if ik == '@xmlns' and isinstance(iv, dict):
+                if ik == attr_prefix + 'xmlns' and isinstance(iv, dict):
                     for k, v in iv.items():
                         _validate_name(k, "attribute")
                         attr = 'xmlns{}'.format(f':{k}' if k else '')


### PR DESCRIPTION
### The bug

`unparse` honors a custom `attr_prefix` for ordinary attributes, but the namespace-declaration branch is hardcoded to the default key `'@xmlns'`. With a custom `attr_prefix`, an xmlns dict is not recognized and falls through to generic attribute handling, where it gets `str()`-ified into one garbage attribute:

```python
import xmltodict
d = {'root': {'!xmlns': {'a': 'http://a/'}, '!id': '7'}}
xmltodict.unparse(d, attr_prefix='!', full_document=False)
# actual:   <root xmlns="{'a': 'http://a/'}" id="7"></root>
# expected: <root xmlns:a="http://a/" id="7"></root>
```

`!id` → `id="7"` shows the custom prefix *is* honored for every other attribute — only the xmlns branch ignores it. This is a self-proving internal inconsistency.

It also breaks a real round-trip: `parse` writes namespace declarations under the custom-prefixed key, so `unparse` can't read them back:

```python
parsed = xmltodict.parse('<root xmlns:a="http://a/"><a:y>2</a:y></root>',
                process_namespaces=True, attr_prefix='!')
# -> {'root': {'!xmlns': {'a': 'http://a/'}, ...}}   # parse writes '!xmlns' (a dict)
# unparse then only looks for '@xmlns' -> the declaration is lost/corrupted
xmltodict.unparse(parsed, attr_prefix='!',
                  namespaces={'http://a/': 'a'}, full_document=False)
# expected: <root xmlns:a="http://a/"><a:y>2</a:y></root>
```

### Root cause

`xmltodict.py`, in `_emit`:

```python
if ik == '@xmlns' and isinstance(iv, dict):
```

`'@xmlns'` is the default-prefix key, hardcoded.

### The fix

Match against `attr_prefix + 'xmlns'`. With the default `attr_prefix='@'` this is byte-identical to `'@xmlns'`, so existing behavior is unchanged:

```python
if ik == attr_prefix + 'xmlns' and isinstance(iv, dict):
```

### Not a documented non-goal

This is positive option semantics — `attr_prefix` is documented as "Prefix for dictionary keys representing attributes" for both `parse` and `unparse`. It's unrelated to the documented non-goals (mixed-content ordering, attribute order, comment round-tripping) and doesn't touch the security defaults.

### Verification

- The repro above now emits `<root xmlns:a="http://a/" id="7"></root>`; the default-`@` xmlns-dict path is byte-for-byte unchanged.
- Added focused dict→XML coverage plus a literal mapped parse→unparse regression assertion in `tests/test_dicttoxml.py`; both fail on `master` and pass with the fix.
- Full suite: `127 passed`.

Independent of open PR #419 (that fixes attribute-name handling when a namespace collapses, a different line — this touches only the `@xmlns`-dict guard).

Scope note: this needs the combination of a custom `attr_prefix` and namespace-declaration dicts, so it's not the most common input — but it's a genuine parse→unparse round-trip corruption, and the one-line fix is provably a no-op for the default prefix.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
