### PR TITLE
fix(unparse): do not XML-escape comment text

### DIFF
--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -749,3 +749,20 @@ def test_pretty_print_top_level_comment_with_int_indent():
     <!--top-->
     <a>1</a>''')
     assert xml == unparse(obj, pretty=True, indent=4)
+
+
+def test_unparse_comment_does_not_escape_special_chars():
+    """Comments must not have their content XML-escaped; & and < are literal in comments."""
+    obj = {"a": {"#comment": "a & b < c > d", "b": "1"}}
+    result = unparse(obj)
+    assert "<!--a & b < c > d-->" in result
+    # Verify round-trip preserves all special chars including quotes
+    parsed = parse(result, process_comments=True)
+    assert parsed["a"]["#comment"] == "a & b < c > d"
+
+    # Also test quotes and > in comments
+    obj2 = {"a": {"#comment": 'say "hello" & \'bye\'', "b": "1"}}
+    result2 = unparse(obj2)
+    assert "<!--say \"hello\" & 'bye'-->" in result2
+    parsed2 = parse(result2, process_comments=True)
+    assert parsed2["a"]["#comment"] == 'say "hello" & \'bye\''

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -2,7 +2,7 @@
 "Makes working with XML feel like you are working with JSON"
 
 from xml.parsers import expat
-from xml.sax.saxutils import XMLGenerator, escape
+from xml.sax.saxutils import XMLGenerator
 from xml.sax.xmlreader import AttributesImpl
 from io import StringIO
 from inspect import isgenerator

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -553,7 +553,7 @@ def _emit(key, value, content_handler,
 class _XMLGenerator(XMLGenerator):
     def comment(self, text):
         text = _validate_comment(text)
-        self._write(f"<!--{escape(text)}-->")
+        self._write(f"<!--{text}-->")
 
 
 def unparse(input_dict, output=None, encoding='utf-8', full_document=True,


### PR DESCRIPTION
## Problem

The `_XMLGenerator.comment()` method passes comment text through `xml.sax.saxutils.escape()`, converting `&` to `&amp;`, `<` to `&lt;`, etc. However, XML comments (`<!-- ... -->`) are **not** parsed for entity references per the XML spec - their content is literal character data. This means a parse -> unparse -> parse round-trip corrupts any comment containing `&`, `<`, `>`, or quotes:

`python
import xmltodict

xml = '<root><!-- a & b --><child>val</child></root>'
d = xmltodict.parse(xml, process_comments=True)
# d == {'root': {'#comment': 'a & b', 'child': 'val'}}

xml2 = xmltodict.unparse(d)
# xml2 contains '<!--a &amp; b-->' - WRONG

d2 = xmltodict.parse(xml2, process_comments=True)
# d2['root']['#comment'] == 'a &amp; b' - data corrupted
``n
## Root cause

Line in `_XMLGenerator.comment()`: `self._write(f'<!--{escape(text)}-->')`  
The `escape()` call is inappropriate here since comment content is not entity-parsed in XML.

## Fix

Remove the `escape()` call. The existing `_validate_comment()` already rejects the only sequences actually illegal in XML comments (`--` and trailing `-`). Regular text node and attribute value escaping is unaffected.

## Validation

- Added regression test `test_unparse_comment_does_not_escape_special_chars` (covers `&`, `<`, `>`, and quotes)
- Verified test **fails** before fix, **passes** after
- Full test suite: **126 tests passed** (125 existing + 1 new)