### PR TITLE
feat(unparse): add opt-in validate_names for XML name grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Convert a Python dictionary back into XML.
 - `indent='\t'`: Indentation string for pretty printing. May also be an integer number of spaces.
 - `newl='\n'`: Newline character for pretty printing.
 - `expand_iter=None`: Tag name to use for items in nested lists (breaks roundtripping).
+- `validate_names=False`: When True, require every element name, attribute name and namespace prefix to be a valid XML name per the [XML 1.0 (Fifth Edition) `Name` production](https://www.w3.org/TR/xml/#NT-Name), raising `ValueError` otherwise. By default only a minimal safety check (which rejects characters that could break out of the markup context) is applied, so names that are safe but not spec-valid — such as `1abc` or an empty name — are still emitted. Enabling this option guarantees the output uses well-formed names; the empty default-namespace prefix (`xmlns="..."`) is preserved.
 
 > **Note:** When building XML from dictionaries, keys whose values are empty
 > lists are skipped. For example, `{'a': []}` produces no `<a>` element. Add a

--- a/tests/test_dicttoxml.py
+++ b/tests/test_dicttoxml.py
@@ -749,3 +749,108 @@ def test_pretty_print_top_level_comment_with_int_indent():
     <!--top-->
     <a>1</a>''')
     assert xml == unparse(obj, pretty=True, indent=4)
+
+
+# --- validate_names: opt-in XML 1.0 Name grammar enforcement (issue #418) ---
+
+def test_validate_names_off_by_default_allows_invalid_but_safe_names():
+    # Without validate_names, a name that is safe (no markup breakout) but not a
+    # valid XML Name is still emitted, preserving backward compatibility.
+    assert unparse({"1abc": "y"}, full_document=False) == "<1abc>y</1abc>"
+    assert (
+        unparse({"a": {"@1x": "v", "#text": "t"}}, full_document=False)
+        == '<a 1x="v">t</a>'
+    )
+
+
+def test_validate_names_accepts_valid_element_names():
+    for name in ["abc", "_abc", "a-b.c", "a1", "café", "Ns:local"]:
+        assert unparse({name: "y"}, full_document=False, validate_names=True) == (
+            f"<{name}>y</{name}>"
+        )
+
+
+def test_validate_names_rejects_invalid_element_names():
+    for name in ["1abc", "", ".x", "-x", ":x", "x:", "a:b:c", "a￿b", "a;b"]:
+        with pytest.raises(ValueError, match="not a valid XML name"):
+            unparse({name: "y"}, full_document=False, validate_names=True)
+
+
+def test_validate_names_rejects_control_char_in_name():
+    with pytest.raises(ValueError, match="not a valid XML name"):
+        unparse({"a\x01b": "y"}, full_document=False, validate_names=True)
+
+
+def test_validate_names_accepts_supplementary_plane_name_char():
+    # Code points in #x10000-#xEFFFF are valid XML name characters.
+    assert unparse({"a\U0001f600": "y"}, full_document=False, validate_names=True) == (
+        "<a\U0001f600>y</a\U0001f600>"
+    )
+
+
+def test_validate_names_checks_attribute_names():
+    assert (
+        unparse({"a": {"@x1": "v", "#text": "t"}}, full_document=False, validate_names=True)
+        == '<a x1="v">t</a>'
+    )
+    with pytest.raises(ValueError, match="not a valid XML name"):
+        unparse({"a": {"@1x": "v", "#text": "t"}}, full_document=False, validate_names=True)
+
+
+def test_validate_names_checks_xmlns_prefixes():
+    # A valid prefix passes.
+    assert (
+        unparse(
+            {"a": {"@xmlns": {"ns": "http://e/"}, "#text": "x"}},
+            full_document=False,
+            validate_names=True,
+        )
+        == '<a xmlns:ns="http://e/">x</a>'
+    )
+    # An invalid prefix is rejected.
+    with pytest.raises(ValueError, match="not a valid XML name"):
+        unparse(
+            {"a": {"@xmlns": {"1ns": "http://e/"}}},
+            full_document=False,
+            validate_names=True,
+        )
+
+
+def test_validate_names_preserves_default_namespace_declaration():
+    # The empty prefix is the default namespace (xmlns="...") and must be
+    # accepted even under strict validation.
+    assert (
+        unparse(
+            {"a": {"@xmlns": {"": "http://e/"}, "#text": "x"}},
+            full_document=False,
+            validate_names=True,
+        )
+        == '<a xmlns="http://e/">x</a>'
+    )
+
+
+def test_validate_names_with_namespace_collapsing_round_trips():
+    obj = {
+        "http://defaultns.com/:root": {
+            "@xmlns": {
+                "": "http://defaultns.com/",
+                "a": "http://a.com/",
+            },
+            "http://a.com/:y": "2",
+        },
+    }
+    ns = {"http://defaultns.com/": "", "http://a.com/": "a"}
+    expected = (
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        '<root xmlns="http://defaultns.com/" xmlns:a="http://a.com/">'
+        "<a:y>2</a:y></root>"
+    )
+    assert unparse(obj, namespaces=ns, validate_names=True) == expected
+
+
+def test_validate_names_full_document():
+    assert unparse({"root": {"child": "v"}}, validate_names=True) == (
+        '<?xml version="1.0" encoding="utf-8"?>\n<root><child>v</child></root>'
+    )
+    with pytest.raises(ValueError, match="not a valid XML name"):
+        unparse({"1root": {"child": "v"}}, validate_names=True)

--- a/xmltodict.py
+++ b/xmltodict.py
@@ -7,6 +7,7 @@ from xml.sax.xmlreader import AttributesImpl
 from io import StringIO
 from inspect import isgenerator
 import codecs
+import re
 
 class ParsingInterrupted(Exception):
     pass
@@ -384,8 +385,47 @@ def _convert_value_to_string(value, encoding='utf-8', bytes_errors='replace'):
     return str(value)
 
 
-def _validate_name(value, kind):
-    """Validate an element/attribute name for XML safety.
+# Character classes for the XML 1.0 (Fifth Edition) ``Name`` production, minus
+# the colon (``:``), which xmltodict treats as the namespace separator rather
+# than an ordinary name character. See https://www.w3.org/TR/xml/#NT-Name.
+_NCNAME_START_CHAR = (
+    "A-Z_a-z"
+    "\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u02ff"
+    "\u0370-\u037d\u037f-\u1fff\u200c-\u200d"
+    "\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff"
+    "\uf900-\ufdcf\ufdf0-\ufffd"
+    "\U00010000-\U000effff"
+)
+_NCNAME_CHAR = _NCNAME_START_CHAR + "\\-.0-9\u00b7\u0300-\u036f\u203f-\u2040"
+_NCNAME_RE = re.compile(f"[{_NCNAME_START_CHAR}][{_NCNAME_CHAR}]*\\Z")
+
+
+def _is_valid_xml_name(value, separator=":"):
+    """Return True if `value` is a valid XML name.
+
+    Names are validated against the XML 1.0 (Fifth Edition) ``Name`` production.
+    When the namespace `separator` is present, `value` is treated as a prefixed
+    name (``prefix:local``) and each side of the single separator must
+    independently be a non-empty ``NCName``, so that namespace prefixes are
+    validated too. An empty `value` is never valid.
+    """
+    if not value:
+        return False
+    if separator and separator in value:
+        parts = value.split(separator)
+        if len(parts) != 2:
+            return False
+        return all(_NCNAME_RE.match(part) for part in parts)
+    return bool(_NCNAME_RE.match(value))
+
+
+def _validate_name(value, kind, strict=False, separator=":"):
+    """Validate an element/attribute name.
+
+    The default (safety) check rejects characters that could break out of the
+    tag/attribute markup context. When `strict` is True, `value` must also be a
+    valid XML name per the XML 1.0 (Fifth Edition) ``Name`` production (see
+    `_is_valid_xml_name`).
 
     Raises ValueError with a specific reason when invalid.
 
@@ -405,6 +445,8 @@ def _validate_name(value, kind):
         raise ValueError(f'Invalid {kind} name: "=" not allowed')
     if any(ch.isspace() for ch in value):
         raise ValueError(f"Invalid {kind} name: whitespace not allowed")
+    if strict and not _is_valid_xml_name(value, separator):
+        raise ValueError(f"Invalid {kind} name: {value!r} is not a valid XML name")
 
 
 def _validate_comment(value):
@@ -453,7 +495,8 @@ def _emit(key, value, content_handler,
           expand_iter=None,
           encoding='utf-8',
           bytes_errors='replace',
-          comment_key='#comment'):
+          comment_key='#comment',
+          validate_names=False):
     if isinstance(key, str) and key == comment_key:
         comments_list = value if isinstance(value, list) else [value]
         if isinstance(indent, int):
@@ -479,8 +522,10 @@ def _emit(key, value, content_handler,
         if result is None:
             return
         key, value = result
-    # Minimal validation to avoid breaking out of tag context
-    _validate_name(key, "element")
+    # Minimal validation to avoid breaking out of tag context; when
+    # validate_names is set, also enforce the full XML Name grammar.
+    _validate_name(key, "element", strict=validate_names,
+                   separator=namespace_separator)
     if not hasattr(value, '__iter__') or isinstance(value, (str, bytes, bytearray, memoryview, dict)):
         value = [value]
     for index, v in enumerate(value):
@@ -510,7 +555,12 @@ def _emit(key, value, content_handler,
                                         attr_prefix)
                 if ik == '@xmlns' and isinstance(iv, dict):
                     for k, v in iv.items():
-                        _validate_name(k, "attribute")
+                        # The empty prefix is the default namespace
+                        # declaration (xmlns="..."), which has no name to
+                        # validate. Prefixes are bare NCNames (no separator).
+                        _validate_name(k, "attribute",
+                                       strict=validate_names and bool(k),
+                                       separator="")
                         attr = 'xmlns{}'.format(f':{k}' if k else '')
                         attrs[attr] = '' if v is None else _convert_value_to_string(
                             v, encoding=encoding, bytes_errors=bytes_errors
@@ -521,7 +571,8 @@ def _emit(key, value, content_handler,
                 elif not isinstance(iv, str):
                     iv = _convert_value_to_string(iv, encoding=encoding, bytes_errors=bytes_errors)
                 attr_name = ik[len(attr_prefix) :]
-                _validate_name(attr_name, "attribute")
+                _validate_name(attr_name, "attribute", strict=validate_names,
+                               separator=namespace_separator)
                 attrs[attr_name] = iv
                 continue
             if isinstance(iv, list) and not iv:
@@ -540,7 +591,8 @@ def _emit(key, value, content_handler,
                   pretty, newl, indent, namespaces=namespaces,
                   namespace_separator=namespace_separator,
                   expand_iter=expand_iter, encoding=encoding,
-                  bytes_errors=bytes_errors, comment_key=comment_key)
+                  bytes_errors=bytes_errors, comment_key=comment_key,
+                  validate_names=validate_names)
         if cdata is not None:
             content_handler.characters(cdata)
         if pretty and children:
@@ -577,6 +629,15 @@ def unparse(input_dict, output=None, encoding='utf-8', full_document=True,
     can be customized with the `newl` and `indent` parameters.
     The `bytes_errors` parameter controls decoding errors for byte values and
     defaults to `'replace'`.
+
+    By default, element and attribute names are only checked for characters
+    that could break out of the markup context. Passing `validate_names=True`
+    additionally requires every element name, attribute name, and namespace
+    prefix to be a valid XML name per the XML 1.0 (Fifth Edition) ``Name``
+    production, raising `ValueError` otherwise. When enabled, the emitted
+    document is guaranteed to use well-formed names (the empty default-namespace
+    prefix, i.e. ``xmlns="..."``, is preserved). This is opt-in to keep
+    backward compatibility; it defaults to `False`.
 
     """
     bytes_errors = kwargs.pop('bytes_errors', 'replace')


### PR DESCRIPTION
## Summary

Fixes #418 (opt-in path).

`unparse()` currently performs only markup-safety validation of names: it rejects characters that could break out of tag/attribute context (`<`, `>`, quotes, `=`, `/`, whitespace, leading `?`/`!`). As the issue notes, names that are *safe* but not valid per the XML spec — e.g. `1abc`, an empty name, or a name containing invalid characters — are still emitted, producing XML that is not well-formed.

This adds an opt-in `validate_names` option to `unparse()`. When enabled, it enforces the full XML name grammar in addition to the existing safety check, so `unparse()` guarantees well-formed names for the whole document.

It's kept opt-in (default `False`) so existing callers are completely unaffected. Happy to make it the default in a future major version if you'd prefer that direction.

## What it does

Following the acceptance criteria in #418:

- **Grammar:** validates against the XML 1.0 (Fifth Edition) [`Name` production](https://www.w3.org/TR/xml/#NT-Name). The character ranges are encoded as compiled regex classes, with the colon excluded from the base `NCName` class (xmltodict treats `:` as the namespace separator).
- **Applied consistently** to element names, attribute names, and namespace prefixes — reusing the existing `_validate_name` call sites so it also runs after preprocessor and namespace collapsing.
- **Namespace prefixes:** a name containing the separator is validated as a prefixed name (`prefix:local`); each side must be a non-empty `NCName`. This rejects `:x`, `x:`, and `a:b:c`.
- **Default namespace preserved:** the empty prefix (`xmlns="..."`) is accepted, matching the existing behavior called out in the issue.
- **Documented** as an `unparse()` guarantee in the docstring and the README API reference.

```python
>>> xmltodict.unparse({"1abc": "x"}, full_document=False)              # unchanged default
'<1abc>x</1abc>'
>>> xmltodict.unparse({"1abc": "x"}, full_document=False, validate_names=True)
ValueError: Invalid element name: '1abc' is not a valid XML name
```

## Tests

Added 10 tests in `tests/test_dicttoxml.py` covering: default behavior is unchanged; valid/invalid element and attribute names (leading digit, empty, leading `.`/`-`, control char, invalid code points); supplementary-plane name characters are accepted; QName/prefix cases; `@xmlns` prefix validation; default-namespace preservation; a namespace-collapsing round trip; and full-document output.

Full suite passes (135 tests), and the new code is fully covered.